### PR TITLE
add missing type ignore

### DIFF
--- a/scanomatic/server/rpcjob.py
+++ b/scanomatic/server/rpcjob.py
@@ -5,7 +5,7 @@ from threading import Thread
 from time import sleep
 
 import psutil
-import setproctitle
+import setproctitle  # type: ignore
 
 from scanomatic.server.proc_effector import (
     ChildPipeEffector,


### PR DESCRIPTION
This single line of code is responsible for going from this
```console
Found 106 errors in 23 files (checked 164 source files)
```
to this
```console
Found 783 errors in 72 files (checked 164 source files)
```
by allowing mypy to not skip things....

While continuing to fix mypy errors is a good thing, this demonstrates that a more structured approach is probably needed.

**Please also not that the build is failing. I haven't looked into why yet!**