### PR TITLE
remove unused test

### DIFF
--- a/scanomatic/ui_server_data/js/tests/components/PlateEditor.test.jsx
+++ b/scanomatic/ui_server_data/js/tests/components/PlateEditor.test.jsx
@@ -39,11 +39,6 @@ describe('<PlateEditor />', () => {
       .toContain('myimage.tiff, Plate 1');
   });
 
-  describe('pre-processing', () => {
-    xit('should render an <AnimatedProgressBar />', () => {
-    });
-  });
-
   describe('gridding', () => {
     it('should render a <PlateContainer />', () => {
       const wrapper = shallow(<PlateEditor {...props} step="gridding" />);


### PR DESCRIPTION
There doesn't appear to be anything in `PlateEditor` to base the state of a progress bar on in the pre-processing state, so removing test.

Resolves #70 