### PR TITLE
Add typed FixtureImage parameter

### DIFF
--- a/scanomatic/image_analysis/analysis_image.py
+++ b/scanomatic/image_analysis/analysis_image.py
@@ -21,7 +21,7 @@ from scanomatic.models.factories.analysis_factories import (
 from . import grid_array
 from .grayscale import get_grayscale
 from .image_basics import load_image_to_numpy
-from .image_grayscale import is_valid_grayscale
+from .grayscale_detection import is_valid_grayscale
 
 
 def _get_init_features(

--- a/scanomatic/image_analysis/exceptions.py
+++ b/scanomatic/image_analysis/exceptions.py
@@ -4,3 +4,7 @@ class LoadImageError(Exception):
 
 class FixtureImageError(Exception):
     pass
+
+
+class GrayscaleError(Exception):
+    pass

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -14,7 +14,7 @@ from scanomatic.models.fixture_models import (
     GrayScaleAreaModel
 )
 
-from . import image_basics, image_fixture, image_grayscale
+from . import grayscale_detection, image_basics, image_fixture
 from .image_basics import load_image_to_numpy
 
 
@@ -466,7 +466,7 @@ class FixtureImage:
             return False
 
         try:
-            current_model.grayscale.values = image_grayscale.get_grayscale(
+            current_model.grayscale.values = grayscale_detection.detect_grayscale(  # noqa: E501
                 self,
                 current_model.grayscale,
             )[1]

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -1,6 +1,6 @@
 import itertools
 import time
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 
@@ -13,8 +13,12 @@ from scanomatic.models.fixture_models import (
     FixturePlateModel,
     GrayScaleAreaModel
 )
+from scanomatic.image_analysis.grayscale_detection import (
+    detect_grayscale,
+)
+from scanomatic.image_analysis.exceptions import GrayscaleError
 
-from . import grayscale_detection, image_basics, image_fixture
+from . import image_basics, image_fixture
 from .image_basics import load_image_to_numpy
 
 
@@ -416,63 +420,16 @@ class FixtureImage:
 
                 return None
 
-    def get_grayscale_im_section(
-        self,
-        grayscale_model: GrayScaleAreaModel,
-        scale=1.0,
-    ) -> Optional[np.ndarray]:
-        im = self.im
-        if im is not None and grayscale_model is not None:
-            try:
-                return im[
-                    int(round(max(grayscale_model.y1 * scale, 0))):
-                    int(round(min(grayscale_model.y2 * scale, im.shape[0]))),
-                    int(round(max(grayscale_model.x1 * scale, 0))):
-                    int(round(min(grayscale_model.x2 * scale, im.shape[1])))
-                ]
-            except (IndexError, TypeError):
-                return None
-
-    def analyse_grayscale(self):
+    def analyse_grayscale(self) -> None:
         current_model = self["current"].model
-        im = self.get_grayscale_im_section(current_model.grayscale, scale=1.0)
-
-        if im is None or 0 in im.shape:
-            err = "No valid grayscale area. "
-            if self.im is None:
-                self._logger.error(err + "No image loaded")
-            elif current_model.grayscale is None:
-                self._logger.error(err + "Grayscale area model not set")
-            elif im is None:
-                self._logger.error(
-                    err
-                    + "Image (shape {0}) could not be sliced according to {1}".format(  # noqa: E501
-                        self.im.shape,
-                        dict(**current_model.grayscale)
-                    ),
-                )
-            elif 0 in im.shape:
-                self._logger.error(
-                    err
-                    + "Grayscale area has bad shape ({0})".format(im.shape),
-                )
-            return False
-
         try:
-            current_model.grayscale.section_values = (
-                grayscale_detection.detect_grayscale(
-                    self,
-                    current_model.grayscale,
-                )[1]
-            )
-        except TypeError:
-            self._logger.exception("Grayscale detection failed")
-            current_model.grayscale.section_values = None
+            current_model.grayscale.section_values = detect_grayscale(
+                self.im,
+                current_model.grayscale,
+            )[1]
 
-        if current_model.grayscale.section_values is None:
-            return False
-
-        return True
+        except GrayscaleError:
+            self._logger.warning("Failed analysing grayscale")
 
     def _set_area_relative(
         self,

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -11,9 +11,9 @@ from scanomatic.io.logger import get_logger
 from scanomatic.io.paths import Paths
 from scanomatic.models.fixture_models import GrayScaleAreaModel
 from scanomatic.image_analysis.first_pass_image import FixtureImage
+from scanomatic.image_analysis.grayscale import Grayscale, get_grayscale
+from scanomatic.image_analysis import signal
 
-from . import signal
-from .grayscale import Grayscale, get_grayscale
 
 ORTH_EDGE_T = 0.2
 ORTH_T1 = 0.15

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
-from scanomatic.models.fixture_models import GrayScaleAreaModel
 from scipy.ndimage import gaussian_filter1d  # type: ignore
 from scipy.signal import convolve2d  # type: ignore
 

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -10,9 +10,9 @@ from scanomatic.generics.maths import mid50_mean as iqr_mean
 from scanomatic.io.logger import get_logger
 from scanomatic.io.paths import Paths
 from scanomatic.models.fixture_models import GrayScaleAreaModel
-from scanomatic.image_analysis.first_pass_image import FixtureImage
-from scanomatic.image_analysis.grayscale import Grayscale, get_grayscale
+from scanomatic.image_analysis.grayscale import Grayscale
 from scanomatic.image_analysis import signal
+from scanomatic.image_analysis.exceptions import GrayscaleError
 
 
 ORTH_EDGE_T = 0.2
@@ -169,37 +169,39 @@ def get_para_trimmed_slice(
     return im_ortho_trimmed
 
 
-def detect_grayscale(
-    fixture: FixtureImage,
-    grayscale_area_model: GrayScaleAreaModel,
-    debug: bool = False,
-) -> tuple[Optional[np.ndarray], Optional[list[float]]]:
-    im = fixture.get_grayscale_im_section(grayscale_area_model)
-    if im is None:
-        return None, None
-    return get_grayscale_image_analysis(
-        im,
-        grayscale_area_model.name,
-        debug=debug,
-    )
-
-
-def get_grayscale_image_analysis(
+def get_grayscale_im_section(
     im: np.ndarray,
-    grayscale_name: str,
+    grayscale_model: GrayScaleAreaModel,
+    scale=1.0,
+) -> np.ndarray:
+    try:
+        return im[
+            int(round(max(grayscale_model.y1 * scale, 0))):
+            int(round(min(grayscale_model.y2 * scale, im.shape[0]))),
+            int(round(max(grayscale_model.x1 * scale, 0))):
+            int(round(min(grayscale_model.x2 * scale, im.shape[1])))
+        ]
+    except (IndexError, TypeError):
+        msg = "Could not extract grayscale section"
+        raise GrayscaleError(msg)
+
+
+def detect_grayscale(
+    image: np.ndarray,
+    grayscale: GrayScaleAreaModel,
     debug: bool = False,
-) -> tuple[Optional[np.ndarray], Optional[list[float]]]:
+) -> tuple[np.ndarray, list[float]]:
     global DEBUG_DETECTION
 
-    grayscale = get_grayscale(grayscale_name)
-    if not im.size:
-        return None, None
-    im_ortho = get_ortho_trimmed_slice(im, grayscale)
+    grayscale_im = get_grayscale_im_section(image, grayscale)
+
+    im_ortho = get_ortho_trimmed_slice(grayscale_im, grayscale)
     if not im_ortho.size:
-        return None, None
+        raise GrayscaleError("Failed to get orthogonal trimmed slice")
     im_para = get_para_trimmed_slice(im_ortho, grayscale)
     if im_para is None or not im_para.size:
-        return None, None
+        raise GrayscaleError("Failed to get parallel trimmed slice")
+
     DEBUG_DETECTION = debug
     return find_grayscale_locations(im_para, grayscale)
 
@@ -249,13 +251,14 @@ def is_valid_grayscale(
 def find_grayscale_locations(
     im_trimmed: np.ndarray,
     grayscale: Grayscale,
-) -> tuple[Optional[np.ndarray], Optional[list[float]]]:
+) -> tuple[np.ndarray, list[float]]:
     gray_scale: list[float] = []
     grayscale_segment_centers: Optional[np.ndarray] = None
 
     if im_trimmed is None or sum(im_trimmed.shape) == 0:
-        _logger.error("No image loaded or null image")
-        return None, None
+        msg = "No image loaded or null image"
+        _logger.error(msg)
+        raise GrayscaleError(msg)
 
     rect = ([0, 0], im_trimmed.shape)
     mid_ortho_slice = (rect[1][1] + rect[0][1]) / 2.0
@@ -328,8 +331,9 @@ def find_grayscale_locations(
 
             fin_edges = np.isfinite(edges)
             if not fin_edges.any():
-                _logger.error("No finite edges found")
-                return None, None
+                msg = "No finite edges found"
+                _logger.error(msg)
+                raise GrayscaleError(msg)
 
             where_fin_edges = np.where(fin_edges)[0]
 
@@ -344,8 +348,9 @@ def find_grayscale_locations(
             frequency = frequency[np.isfinite(frequency)].mean()
 
             if not np.isfinite(frequency):
-                _logger.error("No frequency was detected, thus no grayscale")
-                return None, None
+                msg = "No frequency was detected, thus no grayscale"
+                _logger.error(msg)
+                raise GrayscaleError(msg)
 
             edges = signal.extrapolate_edges(
                 edges,
@@ -354,13 +359,12 @@ def find_grayscale_locations(
             )
 
             if edges.size != grayscale.sections + 1:
-                _logger.error(
-                    "Number of edges doesn't correspond to the grayscale segments ({0}!={1})".format(  # noqa: E501
+                msg = "Number of edges doesn't correspond to the grayscale segments ({0}!={1})".format(  # noqa: E501
                         edges.size,
                         grayscale.sections + 1,
-                    ),
-                )
-                return None, None
+                    )
+                _logger.error(msg)
+                raise GrayscaleError(msg)
 
             # EXTRACTING SECTION MIDPOINTS
             grayscale_segment_centers = np.array(np.interp(
@@ -487,7 +491,7 @@ def find_grayscale_locations(
         )
 
         if s is None:
-            _logger.warning((
+            msg = (
                 "GRAYSCALE, no signal detected for f={0} and"
                 " offset={1} in best_spikes={2} from spikes={3}").format(
                     frequency,
@@ -495,8 +499,8 @@ def find_grayscale_locations(
                     best_spikes,
                     up_spikes,
                 )
-            )
-            return None, None
+            _logger.warning(msg)
+            raise GrayscaleError(msg)
 
         if s[0] - frequency * SAFETY_PADDING < 0:
             _logger.warning(

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -9,7 +9,7 @@ from scanomatic.image_analysis import first_pass_image
 from scanomatic.image_analysis.grayscale import get_grayscale
 from scanomatic.image_analysis.grid_array import GridArray
 from scanomatic.image_analysis.grid_cell import GridCell
-from scanomatic.image_analysis.image_grayscale import (
+from scanomatic.image_analysis.grayscale_detection import (
     get_grayscale_image_analysis
 )
 from scanomatic.io.fixtures import Fixtures

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -6,6 +6,7 @@ from flask import Blueprint, current_app, jsonify, request, send_file
 from scanomatic.data_processing import calibration
 from scanomatic.data_processing.calibration import delete_ccc
 from scanomatic.image_analysis import first_pass_image
+from scanomatic.image_analysis.exceptions import GrayscaleError
 from scanomatic.image_analysis.grayscale import get_grayscale
 from scanomatic.image_analysis.grid_array import GridArray
 from scanomatic.image_analysis.grid_cell import GridCell
@@ -327,8 +328,17 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
         )
 
     grayscale_object = get_grayscale(gs_name)
-    _, values = detect_grayscale(
-        gs_image, gs_name, debug=False)
+    try:
+        _, values = detect_grayscale(
+            gs_image,
+            gs_name,
+            debug=False,
+        )
+    except GrayscaleError:
+        return json_abort(
+            400,
+            reason='Failed to detect grayscale'
+        )
     valid = get_grayscale_is_valid(values, grayscale_object)
     if not valid:
         return json_abort(

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -10,7 +10,7 @@ from scanomatic.image_analysis.grayscale import get_grayscale
 from scanomatic.image_analysis.grid_array import GridArray
 from scanomatic.image_analysis.grid_cell import GridCell
 from scanomatic.image_analysis.grayscale_detection import (
-    get_grayscale_image_analysis
+    detect_grayscale
 )
 from scanomatic.io.fixtures import Fixtures
 from scanomatic.io.paths import Paths
@@ -326,9 +326,9 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
             reason='Unknown image or CCC'
         )
 
-    _, values = get_grayscale_image_analysis(
-        gs_image, gs_name, debug=False)
     grayscale_object = get_grayscale(gs_name)
+    _, values = detect_grayscale(
+        gs_image, gs_name, debug=False)
     valid = get_grayscale_is_valid(values, grayscale_object)
     if not valid:
         return json_abort(

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -23,6 +23,7 @@ from scanomatic.image_analysis.grid_cell import GridCell
 from scanomatic.image_analysis.image_basics import Image_Transpose
 from scanomatic.image_analysis.grayscale_detection import detect_grayscale
 from scanomatic.image_analysis.support import save_image_as_png
+from scanomatic.image_analysis.exceptions import GrayscaleError
 from scanomatic.io.fixtures import Fixtures
 from scanomatic.io.jsonizer import dump, load_first
 from scanomatic.io.logger import get_logger
@@ -271,7 +272,6 @@ def add_routes(app, rpc_client, is_debug_mode):
                 Getting the names of the known grayscales
         """
         raise NotImplementedError("This endpoint is not complete")
-        fixture = None
         data_object = request.get_json(silent=True, force=True)
         if not data_object:
             data_object = request.values
@@ -293,11 +293,11 @@ def add_routes(app, rpc_client, is_debug_mode):
 
         try:
             _, values = detect_grayscale(
-                fixture,
+                image,
                 grayscale_area_model,
                 debug=is_debug_mode,
             )
-        except TypeError:
+        except (TypeError, GrayscaleError):
             return jsonify(
                 success=False, is_endpoint=True,
                 reason="Grayscale detection failed")
@@ -365,8 +365,8 @@ def add_routes(app, rpc_client, is_debug_mode):
 
         try:
             _, values = detect_grayscale(
-                fixture, grayscale_area_model, debug=is_debug_mode)
-        except TypeError:
+                fixture.im, grayscale_area_model, debug=is_debug_mode)
+        except (TypeError, GrayscaleError):
             return jsonify(
                 success=False, is_endpoint=True,
                 reason="Grayscale detection failed")
@@ -581,8 +581,8 @@ def add_routes(app, rpc_client, is_debug_mode):
             grayscale_area_model.name = grayscale_name
 
             try:
-                _, values = detect_grayscale(fixture, grayscale_area_model)
-            except TypeError:
+                _, values = detect_grayscale(fixture.im, grayscale_area_model)
+            except (TypeError, GrayscaleError):
 
                 return jsonify(
                     success=False,

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -22,7 +22,7 @@ from scanomatic.image_analysis.grayscale import (
 from scanomatic.image_analysis.grayscale import get_grayscale_names
 from scanomatic.image_analysis.grid_cell import GridCell
 from scanomatic.image_analysis.image_basics import Image_Transpose
-from scanomatic.image_analysis.image_grayscale import get_grayscale
+from scanomatic.image_analysis.grayscale_detection import detect_grayscale
 from scanomatic.image_analysis.support import save_image_as_png
 from scanomatic.io.fixtures import Fixtures
 from scanomatic.io.jsonizer import dump, load_first
@@ -290,7 +290,7 @@ def add_routes(app, rpc_client, is_debug_mode):
                 grayscale=None, reason="Area too large")
 
         try:
-            _, values = get_grayscale(
+            _, values = detect_grayscale(
                 fixture,
                 grayscale_area_model,
                 debug=is_debug_mode,
@@ -362,7 +362,7 @@ def add_routes(app, rpc_client, is_debug_mode):
         fixture = get_fixture_image_by_name(fixture_name)
 
         try:
-            _, values = get_grayscale(
+            _, values = detect_grayscale(
                 fixture, grayscale_area_model, debug=is_debug_mode)
         except TypeError:
             return jsonify(
@@ -579,7 +579,7 @@ def add_routes(app, rpc_client, is_debug_mode):
             grayscale_area_model.name = grayscale_name
 
             try:
-                _, values = get_grayscale(fixture, grayscale_area_model)
+                _, values = detect_grayscale(fixture, grayscale_area_model)
             except TypeError:
 
                 return jsonify(

--- a/scanomatic/ui_server/general.py
+++ b/scanomatic/ui_server/general.py
@@ -16,7 +16,7 @@ from scanomatic.image_analysis.grayscale import Grayscale
 from werkzeug.datastructures import FileStorage
 
 from scanomatic.image_analysis.first_pass_image import FixtureImage
-from scanomatic.image_analysis.image_grayscale import is_valid_grayscale
+from scanomatic.image_analysis.grayscale_detection import is_valid_grayscale
 from scanomatic.io.app_config import Config
 from scanomatic.io.jsonizer import load_first
 from scanomatic.io.logger import get_logger, parse_log_file


### PR DESCRIPTION
Not sure if I'm misunderstanding the problem but this adds the requested typehint and I don't see any circular import errors.

- Renamed `image_grayscale.py` -> `grayscale_detection.py` to make a clearer distinction from `grayscale.py`
- Renamed `get_grayscale` in `grayscale_detection` -> `detect_grayscale` to avoid confusion with `grayscale.get_grayscale`. I think this name is accurate for the function but please correct me if I'm wrong
- Rename `detect_grayscale` -> `find_grayscale_locations`. Same here as above, please correct me if I'm misunderstanding what the function does

Resolves #118 