### PR TITLE
Remove fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "fix": "^0.0.6",
         "jasmine-ajax": "^4.0.0",
         "jasmine-core": "^4.0.0",
-        "karma": "^6.3.11",
+        "karma": "^6.3.12",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage": "^2.1.0",
         "karma-jasmine": "^4.0.1",
@@ -47,7 +47,7 @@
         "react-test-renderer": "^16.0.0",
         "style-loader": "^2.0.0",
         "webpack": "^4.46.0",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.9.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+      "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
       "dev": true,
       "peerDependencies": {
         "webpack": "4.x.x || 5.x.x",
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+      "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
       "dev": true,
       "dependencies": {
         "envinfo": "^7.7.3"
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+      "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
       "dev": true,
       "peerDependencies": {
         "webpack-cli": "4.x.x"
@@ -6385,9 +6385,9 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.12.tgz",
+      "integrity": "sha512-qwIG+oB2YmHx4hjvYSRMNzL3YWAJ9baHaLAxiP7biFNkfpwYTUTtPck0joFpucalNLzMr+7z/FX1uY/kl8DV9A==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -11318,15 +11318,15 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+      "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.1.0",
-        "@webpack-cli/info": "^1.4.0",
-        "@webpack-cli/serve": "^1.6.0",
+        "@webpack-cli/configtest": "^1.1.1",
+        "@webpack-cli/info": "^1.4.1",
+        "@webpack-cli/serve": "^1.6.1",
         "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
@@ -12656,25 +12656,25 @@
       }
     },
     "@webpack-cli/configtest": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
+      "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
+      "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
       }
     },
     "@webpack-cli/serve": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
+      "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
       "dev": true,
       "requires": {}
     },
@@ -17099,9 +17099,9 @@
       }
     },
     "karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.12.tgz",
+      "integrity": "sha512-qwIG+oB2YmHx4hjvYSRMNzL3YWAJ9baHaLAxiP7biFNkfpwYTUTtPck0joFpucalNLzMr+7z/FX1uY/kl8DV9A==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
@@ -21334,15 +21334,15 @@
       }
     },
     "webpack-cli": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
+      "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.1.0",
-        "@webpack-cli/info": "^1.4.0",
-        "@webpack-cli/serve": "^1.6.0",
+        "@webpack-cli/configtest": "^1.1.1",
+        "@webpack-cli/info": "^1.4.1",
+        "@webpack-cli/serve": "^1.6.1",
         "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "scanomatic-standalone",
       "dependencies": {
         "bootstrap": "^3.4.0",
         "bootstrap-toggle": "^2.2.2",
@@ -35,7 +36,6 @@
         "eslint-plugin-jsx-a11y": "^6.0.2",
         "eslint-plugin-react": "^7.5.1",
         "file-loader": "^6.2.0",
-        "fix": "^0.0.6",
         "jasmine-ajax": "^4.0.0",
         "jasmine-core": "^4.0.0",
         "karma": "^6.3.12",
@@ -3291,9 +3291,9 @@
       "dev": true
     },
     "node_modules/date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -4873,20 +4873,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/fix": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/fix/-/fix-0.0.6.tgz",
-      "integrity": "sha1-B+WTonQU3cSG7lLVD5yOCYhaAwU=",
-      "dev": true,
-      "dependencies": {
-        "pipe": "0.0.2",
-        "underscore": "1.1.6",
-        "underscore.string": "1.1.4"
-      },
-      "engines": {
-        "node": ">=0.4.8"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4995,17 +4981,17 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
       }
     },
     "node_modules/fs-write-stream-atomic": {
@@ -6363,10 +6349,13 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6848,16 +6837,16 @@
       }
     },
     "node_modules/log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",
       "dev": true,
       "dependencies": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       },
       "engines": {
         "node": ">=8.0"
@@ -6879,12 +6868,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/log4js/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true
     },
     "node_modules/log4js/node_modules/ms": {
       "version": "2.1.2",
@@ -8069,15 +8052,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pipe": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pipe/-/pipe-0.0.2.tgz",
-      "integrity": "sha1-oW/m/AGddb2YfEkopn4eUOT1tE8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.8"
       }
     },
     "node_modules/pkg-dir": {
@@ -9629,26 +9603,17 @@
       "dev": true
     },
     "node_modules/streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "dependencies": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^10.0.0"
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/date-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-      "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/streamroller/node_modules/debug": {
@@ -10514,27 +10479,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-      "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/underscore.string": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.4.tgz",
-      "integrity": "sha1-m+BrI7jj2ZbqICD5mEICBp497hI=",
-      "dev": true,
-      "dependencies": {
-        "underscore": "1.1.6"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -10569,12 +10513,12 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -14738,9 +14682,9 @@
       "dev": true
     },
     "date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true
     },
     "debug": {
@@ -15976,17 +15920,6 @@
         "locate-path": "^2.0.0"
       }
     },
-    "fix": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/fix/-/fix-0.0.6.tgz",
-      "integrity": "sha1-B+WTonQU3cSG7lLVD5yOCYhaAwU=",
-      "dev": true,
-      "requires": {
-        "pipe": "0.0.2",
-        "underscore": "1.1.6",
-        "underscore.string": "1.1.4"
-      }
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -16065,14 +15998,14 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -17080,12 +17013,13 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsx-ast-utils": {
@@ -17473,16 +17407,16 @@
       }
     },
     "log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",
       "dev": true,
       "requires": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -17493,12 +17427,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -18439,12 +18367,6 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
-    },
-    "pipe": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pipe/-/pipe-0.0.2.tgz",
-      "integrity": "sha1-oW/m/AGddb2YfEkopn4eUOT1tE8=",
-      "dev": true
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -19702,22 +19624,16 @@
       "dev": true
     },
     "streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "requires": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^10.0.0"
       },
       "dependencies": {
-        "date-format": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
-          "dev": true
-        },
         "debug": {
           "version": "4.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -20371,21 +20287,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "underscore": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-      "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw=",
-      "dev": true
-    },
-    "underscore.string": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.4.tgz",
-      "integrity": "sha1-m+BrI7jj2ZbqICD5mEICBp497hI=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.1.6"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -20417,9 +20318,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fix": "^0.0.6",
     "jasmine-ajax": "^4.0.0",
     "jasmine-core": "^4.0.0",
-    "karma": "^6.3.11",
+    "karma": "^6.3.12",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.1.0",
     "karma-jasmine": "^4.0.1",
@@ -33,7 +33,7 @@
     "react-test-renderer": "^16.0.0",
     "style-loader": "^2.0.0",
     "webpack": "^4.46.0",
-    "webpack-cli": "^4.9.1"
+    "webpack-cli": "^4.9.2"
   },
   "dependencies": {
     "bootstrap": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "^6.2.0",
-    "fix": "^0.0.6",
     "jasmine-ajax": "^4.0.0",
     "jasmine-core": "^4.0.0",
     "karma": "^6.3.12",

--- a/scanomatic/data_processing/norm.py
+++ b/scanomatic/data_processing/norm.py
@@ -224,7 +224,7 @@ def _get_positions(data, offsets):
         offset = offsets[id_plate]
         filt = np.tile(
             offset,
-            [a / b for a, b in zip(plate.shape, offset.shape)],
+            [a // b for a, b in zip(plate.shape, offset.shape)],
         )
         filt = filt.reshape(
             filt.shape + tuple(1 for _ in range(plate.ndim - filt.ndim)),
@@ -648,12 +648,12 @@ def apply_outlier_filter(
 
                     if measure is None:
                         plate[
-                            pos / plate.shape[1],
+                            pos // plate.shape[1],
                             pos % plate.shape[1]
                         ] = np.nan
                     else:
                         plate[
-                            pos / plate.shape[1],
+                            pos // plate.shape[1],
                             pos % plate.shape[1],
                             measure
                         ] = np.nan

--- a/scanomatic/data_processing/pheno/save.py
+++ b/scanomatic/data_processing/pheno/save.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pickle
 import zipfile
@@ -7,6 +8,7 @@ from typing import Optional
 import numpy as np
 
 import scanomatic.io.paths as paths
+import scanomatic.io.jsonizer as jsonizer
 from scanomatic.data_processing.pheno.state import (
     PhenotyperSettings,
     PhenotyperState
@@ -127,7 +129,10 @@ def save_state(
         or not os.path.isfile(p)
         or _do_ask_overwrite(p)
     ):
-        np.save(p, settings.serialized())
+        with open(p, 'w') as fp:
+            json.dump(json.loads(
+                jsonizer.dumps(settings.asdict()),
+            ), fp)
 
     _logger.info("State saved to '{0}'".format(dir_path))
 

--- a/scanomatic/data_processing/pheno/save.py
+++ b/scanomatic/data_processing/pheno/save.py
@@ -140,12 +140,11 @@ def save_state_to_zip(
     state: PhenotyperState,
     target: Optional[str] = None,
 ) -> Optional[BytesIO]:
-    JsonizerStateWriter = Callable[[BufferedWriter, Any], int]
-    PickleStateWriter = Callable[[BufferedWriter, Any], None]
-    save_jsonizer: JsonizerStateWriter = (
+    StateWriter = Callable[[BufferedWriter, Any], Any]
+    save_jsonizer: StateWriter = (
         lambda fh, obj: fh.write(jsonizer.dumps(obj).encode())
     )
-    save_pickle: PickleStateWriter = lambda fh, obj: pickle.dump(obj, fh)
+    save_pickle: StateWriter = lambda fh, obj: pickle.dump(obj, fh)
 
     def zipit(save_functions, data, zip_paths):
         zip_buffer = BytesIO()
@@ -181,9 +180,9 @@ def save_state_to_zip(
     if not dir_path or not dir_path.strip() or dir_path == ".":
         dir_path = "analysis"
 
-    save_functions: list[Callable] = []
+    save_functions: list[StateWriter] = []
     data: list[Any] = []
-    zip_paths = []
+    zip_paths: list[str] = []
 
     # Phenotypes
     zip_paths.append(

--- a/scanomatic/data_processing/pheno/save.py
+++ b/scanomatic/data_processing/pheno/save.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from typing import Optional
 
 import numpy as np
+from dataclasses import asdict
 
 import scanomatic.io.paths as paths
 import scanomatic.io.jsonizer as jsonizer
@@ -131,7 +132,7 @@ def save_state(
     ):
         with open(p, 'w') as fp:
             json.dump(json.loads(
-                jsonizer.dumps(settings.asdict()),
+                jsonizer.dumps(asdict(settings)),
             ), fp)
 
     _logger.info("State saved to '{0}'".format(dir_path))

--- a/scanomatic/data_processing/pheno/save.py
+++ b/scanomatic/data_processing/pheno/save.py
@@ -262,8 +262,8 @@ def save_state_to_zip(
     zip_paths.append(
         os.path.join(dir_path, _paths.phenotypes_extraction_params),
     )
-    save_functions.append(np.save)
-    data.append(settings.serialized())
+    save_functions.append(lambda fh, obj: json.dump(obj, fh))
+    data.append(json.loads(jsonizer.dumps(settings.asdict())))
 
     zip_stream = zipit(save_functions, data, zip_paths)
     if target:

--- a/scanomatic/data_processing/pheno/state.py
+++ b/scanomatic/data_processing/pheno/state.py
@@ -1,5 +1,5 @@
 from collections import deque
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -35,8 +35,8 @@ class PhenotyperSettings:
     gaussian_filter_sigma: float
     linear_regression_size: int
     phenotypes_inclusion: Optional[PhenotypeDataType]
-    no_growth_monotonicity_threshold: float
-    no_growth_pop_doublings_threshold: float
+    no_growth_monotonicity_threshold: Optional[float]
+    no_growth_pop_doublings_threshold: Optional[float]
 
     def __post_init__(self):
         assert (
@@ -50,9 +50,14 @@ class PhenotyperSettings:
             self.linear_regression_size,
             None if self.phenotypes_inclusion is None
             else self.phenotypes_inclusion.name,
-            self.no_growth_monotonicity_threshold,
-            self.no_growth_pop_doublings_threshold
+            None if self.no_growth_monotonicity_threshold is None
+            else self.no_growth_monotonicity_threshold,
+            None if self.no_growth_pop_doublings_threshold is None
+            else self.no_growth_pop_doublings_threshold,
         ]
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass

--- a/scanomatic/data_processing/pheno/state.py
+++ b/scanomatic/data_processing/pheno/state.py
@@ -1,5 +1,5 @@
 from collections import deque
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -42,22 +42,6 @@ class PhenotyperSettings:
         assert (
             self.median_kernel_size % 2 == 1
         ), "Median kernel size must be odd"
-
-    def serialized(self) -> list[Union[str, int, float]]:
-        return [
-            self.median_kernel_size,
-            self.gaussian_filter_sigma,
-            self.linear_regression_size,
-            None if self.phenotypes_inclusion is None
-            else self.phenotypes_inclusion.name,
-            None if self.no_growth_monotonicity_threshold is None
-            else self.no_growth_monotonicity_threshold,
-            None if self.no_growth_pop_doublings_threshold is None
-            else self.no_growth_pop_doublings_threshold,
-        ]
-
-    def asdict(self) -> dict[str, Any]:
-        return asdict(self)
 
 
 @dataclass

--- a/scanomatic/data_processing/pheno/state.py
+++ b/scanomatic/data_processing/pheno/state.py
@@ -34,9 +34,11 @@ class PhenotyperSettings:
     median_kernel_size: int
     gaussian_filter_sigma: float
     linear_regression_size: int
-    phenotypes_inclusion: Optional[PhenotypeDataType]
-    no_growth_monotonicity_threshold: Optional[float]
-    no_growth_pop_doublings_threshold: Optional[float]
+    phenotypes_inclusion: Optional[PhenotypeDataType] = (
+        PhenotypeDataType.Trusted
+    )
+    no_growth_monotonicity_threshold: Optional[float] = None
+    no_growth_pop_doublings_threshold: Optional[float] = None
 
     def __post_init__(self):
         assert (

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -332,7 +332,6 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         )
 
         try:
-            
             extraction_params = jsonizer.load(os.path.join(
                 directory_path,
                 _p.phenotypes_extraction_params,

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -353,10 +353,9 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             )
         else:
             try:
-                phenotype_inclusion = extraction_params.get(
+                if (phenotype_inclusion := extraction_params.get(
                     "phenotype_inclusion",
-                )
-                if phenotype_inclusion is not None:
+                )) is not None:
                     phenotyper.set_phenotype_inclusion_level(
                         phenotype_inclusion,
                     )
@@ -364,17 +363,16 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
                     phenotyper.set_phenotype_inclusion_level(
                         PhenotypeDataType.Trusted,
                     )
-                no_growth_monotonicity_threshold = extraction_params.get(
+                if (no_growth_monotonicity_threshold := extraction_params.get(
                     "no_growth_monotonicity_threshold",
-                )
-                if no_growth_monotonicity_threshold is not None:
+
+                )) is not None:
                     phenotyper._settings.no_growth_monotonicity_threshold = (
                         no_growth_monotonicity_threshold
                     )
-                no_growth_pop_doublings_threshold = extraction_params.get(
+                if (no_growth_pop_doublings_threshold := extraction_params.get(
                     "no_growth_pop_doublings_threshold",
-                )
-                if no_growth_pop_doublings_threshold is not None:
+                )) is not None:
                     phenotyper._settings.no_growth_pop_doublings_threshold = (
                         no_growth_pop_doublings_threshold
                     )

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -150,7 +150,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             phenotypes_inclusion=phenotypes_inclusion,
             no_growth_monotonicity_threshold=no_growth_monotonocity_threshold,
             no_growth_pop_doublings_threshold=(
-                no_growth_pop_doublings_threshold,
+                no_growth_pop_doublings_threshold
             ),
         )
         self._state = PhenotyperState(
@@ -380,10 +380,10 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
                     extraction_params["median_kernel_size"]
                 )
                 phenotyper._settings.gaussian_filter_sigma = (
-                    extraction_params["gaussian_filter_sigma"],
+                    extraction_params["gaussian_filter_sigma"]
                 )
                 phenotyper._settings.linear_regression_size = (
-                    extraction_params["linear_regression_size"],
+                    extraction_params["linear_regression_size"]
                 )
             except (ValueError, KeyError):
                 raise ValueError(

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -1,4 +1,5 @@
 import csv
+import pickle
 import os
 from collections import deque
 from collections.abc import Callable, Generator
@@ -55,7 +56,7 @@ from scanomatic.data_processing.strain_selector import StrainSelector
 from scanomatic.generics.phenotype_filter import Filter, FilterArray
 from scanomatic.io.logger import get_logger
 from scanomatic.io.meta_data import MetaData2
-from scanomatic.io.pickler import safe_load, unpickle
+from scanomatic.io.pickler import safe_load
 from . import mock_numpy_interface
 
 # TODO: Something is wrong with phase features again
@@ -457,7 +458,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             try:
                 phenotyper.set(
                     "phenotype_filter_undo",
-                    unpickle(filter_undo_path),
+                    pickle.load(safe_load(filter_undo_path)),
                 )
             except EOFError:
                 phenotyper._logger.warning(
@@ -472,7 +473,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             try:
                 phenotyper.set(
                     "meta_data",
-                    unpickle(meta_data_path),
+                    pickle.load(safe_load(meta_data_path)),
                 )
             except EOFError:
                 phenotyper._logger.warning(

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -344,7 +344,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         )
 
         try:
-            extraction_params = jsonizer.load(os.path.join(
+            phenotyper._settings = jsonizer.load(os.path.join(
                 directory_path,
                 _p.phenotypes_extraction_params,
             ))
@@ -352,49 +352,6 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             phenotyper._logger.warning(
                 "Could not find stored extraction parameters, assuming defaults were used",  # noqa: E501
             )
-        else:
-            try:
-                if (phenotype_inclusion := extraction_params.get(
-                    "phenotype_inclusion",
-                )) is not None:
-                    phenotyper.set_phenotype_inclusion_level(
-                        phenotype_inclusion,
-                    )
-                else:
-                    phenotyper.set_phenotype_inclusion_level(
-                        PhenotypeDataType.Trusted,
-                    )
-                if (no_growth_monotonicity_threshold := extraction_params.get(
-                    "no_growth_monotonicity_threshold",
-
-                )) is not None:
-                    phenotyper._settings.no_growth_monotonicity_threshold = (
-                        no_growth_monotonicity_threshold
-                    )
-                if (no_growth_pop_doublings_threshold := extraction_params.get(
-                    "no_growth_pop_doublings_threshold",
-                )) is not None:
-                    phenotyper._settings.no_growth_pop_doublings_threshold = (
-                        no_growth_pop_doublings_threshold
-                    )
-                phenotyper._settings.median_kernel_size = (
-                    extraction_params["median_kernel_size"]
-                )
-                phenotyper._settings.gaussian_filter_sigma = (
-                    extraction_params["gaussian_filter_sigma"]
-                )
-                phenotyper._settings.linear_regression_size = (
-                    extraction_params["linear_regression_size"]
-                )
-            except (ValueError, KeyError):
-                raise ValueError(
-                    "Stored parameters in {0} can't be understood".format(
-                        os.path.join(
-                            directory_path,
-                            _p.phenotypes_extraction_params,
-                        )
-                    ),
-                )
 
         phenotyper.set('smooth_growth_data', smooth_growth_data)
         phenotyper.set('phenotypes', phenotypes)

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -2215,7 +2215,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         )
 
         if undoable:
-            self._add_undo(plate, positions, phenotype, previous_state)
+            self._add_undo(id_plate, positions, phenotype, previous_state)
 
     def _add_undo(self, plate, position_list, phenotype, previous_state):
 

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -1,5 +1,4 @@
 import csv
-import json
 import os
 from collections import deque
 from collections.abc import Callable, Generator

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -55,8 +55,7 @@ from scanomatic.data_processing.strain_selector import StrainSelector
 from scanomatic.generics.phenotype_filter import Filter, FilterArray
 from scanomatic.io.logger import get_logger
 from scanomatic.io.meta_data import MetaData2
-from scanomatic.io.pickler import unpickle, unpickle_with_unpickler
-
+from scanomatic.io.pickler import safe_load, unpickle
 from . import mock_numpy_interface
 
 # TODO: Something is wrong with phase features again
@@ -270,15 +269,19 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         """
         _p = paths.Paths()
 
-        raw_growth_data = unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path, _p.phenotypes_input_data),
+        raw_growth_data = np.load(
+            safe_load(os.path.join(
+                directory_path,
+                _p.phenotypes_input_data,
+            )),
             allow_pickle=True,
         )
 
-        times = unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path, _p.phenotype_times),
+        times = np.load(
+            safe_load(os.path.join(
+                directory_path,
+                _p.phenotype_times,
+            )),
             allow_pickle=True,
         )
 
@@ -290,9 +293,11 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         )
 
         try:
-            phenotypes = unpickle_with_unpickler(
-                np.load,
-                os.path.join(directory_path, _p.phenotypes_raw_npy),
+            phenotypes = np.load(
+                safe_load(os.path.join(
+                    directory_path,
+                    _p.phenotypes_raw_npy,
+                )),
                 allow_pickle=True,
             )
         except (IOError, ValueError):
@@ -302,9 +307,11 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             phenotypes = None
 
         try:
-            vector_phenotypes = unpickle_with_unpickler(
-                np.load,
-                os.path.join(directory_path, _p.vector_phenotypes_raw),
+            vector_phenotypes = np.load(
+                safe_load(os.path.join(
+                    directory_path,
+                    _p.vector_phenotypes_raw,
+                )),
                 allow_pickle=True,
             )
         except (IOError, ValueError):
@@ -314,9 +321,11 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             vector_phenotypes = None
 
         try:
-            vector_meta_phenotypes = unpickle_with_unpickler(
-                np.load,
-                os.path.join(directory_path, _p.vector_meta_phenotypes_raw),
+            vector_meta_phenotypes = np.load(
+                safe_load(os.path.join(
+                    directory_path,
+                    _p.vector_meta_phenotypes_raw,
+                )),
                 allow_pickle=True,
             )
         except (IOError, ValueError):
@@ -325,9 +334,11 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             )
             vector_meta_phenotypes = None
 
-        smooth_growth_data = unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path, _p.phenotypes_input_smooth),
+        smooth_growth_data = np.load(
+            safe_load(os.path.join(
+                directory_path,
+                _p.phenotypes_input_smooth,
+            )),
             allow_pickle=True,
         )
 
@@ -399,9 +410,8 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             try:
                 phenotyper.set(
                     "phenotype_filter",
-                    unpickle_with_unpickler(
-                        np.load,
-                        filter_path,
+                    np.load(
+                        safe_load(filter_path),
                         allow_pickle=True,
                     ),
                 )
@@ -417,9 +427,8 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         if os.path.isfile(offsets_path):
             phenotyper.set(
                 "reference_offsets",
-                unpickle_with_unpickler(
-                    np.load,
-                    offsets_path,
+                np.load(
+                    safe_load(offsets_path),
                     allow_pickle=True,
                 ),
             )
@@ -432,9 +441,8 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             try:
                 phenotyper.set(
                     "normalized_phenotypes",
-                    unpickle_with_unpickler(
-                        np.load,
-                        normalized_phenotypes,
+                    np.load(
+                        safe_load(normalized_phenotypes),
                         allow_pickle=True,
                     ),
                 )
@@ -544,14 +552,12 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
                 times_data_path += ".npy"
 
         return cls(
-            unpickle_with_unpickler(
-                np.load,
-                data_directory,
+            np.load(
+                safe_load(data_directory),
                 allow_pickle=True,
             ),
-            unpickle_with_unpickler(
-                np.load,
-                times_data_path,
+            np.load(
+                safe_load(times_data_path),
                 allow_pickle=True,
             ),
             base_name=path,

--- a/scanomatic/data_processing/project.py
+++ b/scanomatic/data_processing/project.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 
 import numpy as np
@@ -24,6 +25,7 @@ def path_has_saved_project_state(
             unpickle_with_unpickler(
                 np.load,
                 os.path.join(directory_path, _p.phenotypes_raw_npy),
+                allow_pickle=True,
             )
         except IOError:
             return False
@@ -32,19 +34,23 @@ def path_has_saved_project_state(
         unpickle_with_unpickler(
             np.load,
             os.path.join(directory_path,  _p.phenotypes_input_data),
+            allow_pickle=True,
         )
         unpickle_with_unpickler(
             np.load,
             os.path.join(directory_path, _p.phenotype_times),
+            allow_pickle=True,
         )
         unpickle_with_unpickler(
             np.load,
             os.path.join(directory_path, _p.phenotypes_input_smooth),
+            allow_pickle=True,
         )
-        unpickle_with_unpickler(
-            np.load,
+        with open(
             os.path.join(directory_path, _p.phenotypes_extraction_params),
-        )
+            'r',
+        ) as fp:
+            json.load(fp)
     except IOError:
         return False
     return True

--- a/scanomatic/data_processing/project.py
+++ b/scanomatic/data_processing/project.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import scanomatic.io.paths as paths
 from scanomatic.io.logger import get_logger
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 
 _logger = get_logger("Project")
 
@@ -22,28 +22,24 @@ def path_has_saved_project_state(
 
     if require_phenotypes:
         try:
-            unpickle_with_unpickler(
-                np.load,
-                os.path.join(directory_path, _p.phenotypes_raw_npy),
+            np.load(
+                safe_load(os.path.join(directory_path, _p.phenotypes_raw_npy)),
                 allow_pickle=True,
             )
         except IOError:
             return False
 
     try:
-        unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path,  _p.phenotypes_input_data),
+        np.load(
+            safe_load(os.path.join(directory_path,  _p.phenotypes_input_data)),
             allow_pickle=True,
         )
-        unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path, _p.phenotype_times),
+        np.load(
+            safe_load(os.path.join(directory_path, _p.phenotype_times)),
             allow_pickle=True,
         )
-        unpickle_with_unpickler(
-            np.load,
-            os.path.join(directory_path, _p.phenotypes_input_smooth),
+        np.load(
+            safe_load(os.path.join(directory_path, _p.phenotypes_input_smooth)),
             allow_pickle=True,
         )
         with open(

--- a/scanomatic/data_processing/project.py
+++ b/scanomatic/data_processing/project.py
@@ -1,10 +1,10 @@
 import glob
-import json
 import os
 
 import numpy as np
 
 import scanomatic.io.paths as paths
+from scanomatic.io import jsonizer
 from scanomatic.io.logger import get_logger
 from scanomatic.io.pickler import safe_load
 
@@ -42,11 +42,7 @@ def path_has_saved_project_state(
             safe_load(os.path.join(directory_path, _p.phenotypes_input_smooth)),
             allow_pickle=True,
         )
-        with open(
-            os.path.join(directory_path, _p.phenotypes_extraction_params),
-            'r',
-        ) as fp:
-            json.load(fp)
+        jsonizer.load(os.path.join(directory_path, _p.phenotypes_extraction_params))
     except IOError:
         return False
     return True

--- a/scanomatic/data_processing/project.py
+++ b/scanomatic/data_processing/project.py
@@ -42,7 +42,9 @@ def path_has_saved_project_state(
             safe_load(os.path.join(directory_path, _p.phenotypes_input_smooth)),
             allow_pickle=True,
         )
-        jsonizer.load(os.path.join(directory_path, _p.phenotypes_extraction_params))
+        jsonizer.load(
+            os.path.join(directory_path, _p.phenotypes_extraction_params),
+        )
     except IOError:
         return False
     return True

--- a/scanomatic/image_analysis/grid_array.py
+++ b/scanomatic/image_analysis/grid_array.py
@@ -7,7 +7,7 @@ from scanomatic.io.logger import get_logger
 
 import scanomatic.io.paths as paths
 from scanomatic.image_analysis.grayscale import get_grayscale
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 from scanomatic.models.analysis_model import IMAGE_ROTATIONS
 from scanomatic.models.compile_project_model import CompileImageAnalysisModel
 from scanomatic.models.factories.analysis_factories import (
@@ -244,9 +244,8 @@ class GridArray:
                 )
 
         try:
-            grid = unpickle_with_unpickler(
-                np.load,
-                grid,
+            grid = np.load(
+                safe_load(grid),
                 allow_pickle=True,
             )
         except IOError:

--- a/scanomatic/image_analysis/grid_array.py
+++ b/scanomatic/image_analysis/grid_array.py
@@ -244,7 +244,11 @@ class GridArray:
                 )
 
         try:
-            grid = unpickle_with_unpickler(np.load, grid)
+            grid = unpickle_with_unpickler(
+                np.load,
+                grid,
+                allow_pickle=True,
+            )
         except IOError:
             self._LOGGER.error("No grid file named '{0}'".format(grid))
             self._LOGGER.info("Invoking grid detection instead")

--- a/scanomatic/io/app_config.py
+++ b/scanomatic/io/app_config.py
@@ -253,7 +253,7 @@ class Config(SingeltonOneInit):
             dump(
                 self._settings,
                 self._paths.config_main_app,
-                overwrite=True,
+                merge=True,
             )
 
     def get_scanner_socket(self, scanner: Union[int, str]) -> Optional[int]:

--- a/scanomatic/io/fixtures.py
+++ b/scanomatic/io/fixtures.py
@@ -86,7 +86,7 @@ class FixtureSettings:
         dump(
             self.model,
             self.path,
-            overwrite=True,
+            merge=True,
         )
 
 

--- a/scanomatic/io/image_data.py
+++ b/scanomatic/io/image_data.py
@@ -7,7 +7,7 @@ import numpy as np
 from scanomatic.io.logger import get_logger
 
 import scanomatic.io.paths as paths
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 from scanomatic.models.analysis_model import (
     COMPARTMENTS,
     MEASURES,
@@ -159,9 +159,8 @@ class ImageData:
             path,
         ))
         if os.path.isfile(path):
-            return unpickle_with_unpickler(
-                np.load,
-                path,
+            return np.load(
+                safe_load(path),
                 allow_pickle=True,
             )
         else:
@@ -171,9 +170,8 @@ class ImageData:
     @staticmethod
     def read_image(path: str):
         if os.path.isfile(path):
-            return unpickle_with_unpickler(
-                np.load,
-                path,
+            return np.load(
+                safe_load(path),
                 allow_pickle=True,
             )
         else:
@@ -314,9 +312,8 @@ class ImageData:
 
             try:
                 time_indices.append(int(re.findall(r"\d+", p)[-1]))
-                data.append(unpickle_with_unpickler(
-                    np.load,
-                    p,
+                data.append(np.load(
+                    safe_load(p),
                     allow_pickle=True,
                 ))
             except AttributeError:

--- a/scanomatic/io/image_data.py
+++ b/scanomatic/io/image_data.py
@@ -159,7 +159,11 @@ class ImageData:
             path,
         ))
         if os.path.isfile(path):
-            return unpickle_with_unpickler(np.load, path)
+            return unpickle_with_unpickler(
+                np.load,
+                path,
+                allow_pickle=True,
+            )
         else:
             ImageData._LOGGER.warning("Times data file not found")
             return np.array([], dtype=float)
@@ -167,7 +171,11 @@ class ImageData:
     @staticmethod
     def read_image(path: str):
         if os.path.isfile(path):
-            return unpickle_with_unpickler(np.load, path)
+            return unpickle_with_unpickler(
+                np.load,
+                path,
+                allow_pickle=True,
+            )
         else:
             return None
 
@@ -306,7 +314,11 @@ class ImageData:
 
             try:
                 time_indices.append(int(re.findall(r"\d+", p)[-1]))
-                data.append(unpickle_with_unpickler(np.load, p))
+                data.append(unpickle_with_unpickler(
+                    np.load,
+                    p,
+                    allow_pickle=True,
+                ))
             except AttributeError:
                 ImageData._LOGGER.warning(
                     f"File '{p}' has no index number in it, need that!",

--- a/scanomatic/io/image_loading.py
+++ b/scanomatic/io/image_loading.py
@@ -92,6 +92,7 @@ def _load_grid_info(analysis_directory, plate):
             analysis_directory,
             Paths().grid_pattern.format(plate + 1),
         ),
+        allow_pickle=True,
     )
     grid_size = unpickle_with_unpickler(
         np.load,
@@ -99,6 +100,7 @@ def _load_grid_info(analysis_directory, plate):
             analysis_directory,
             Paths().grid_size_pattern.format((plate + 1)),
         ),
+        allow_pickle=True,
     )
     return grid, grid_size
 

--- a/scanomatic/io/image_loading.py
+++ b/scanomatic/io/image_loading.py
@@ -9,7 +9,7 @@ from scanomatic.image_analysis.image_basics import load_image_to_numpy
 from scanomatic.io.jsonizer import load
 from scanomatic.io.logger import get_logger
 from scanomatic.io.paths import Paths
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 from scanomatic.models.compile_project_model import CompileImageAnalysisModel
 
 _logger = get_logger("Image loader")
@@ -86,20 +86,18 @@ def slice_im(plate_im, colony_position, colony_size):
 
 def _load_grid_info(analysis_directory, plate):
     # grids number +1
-    grid = unpickle_with_unpickler(
-        np.load,
-        os.path.join(
+    grid = np.load(
+        safe_load(os.path.join(
             analysis_directory,
             Paths().grid_pattern.format(plate + 1),
-        ),
+        )),
         allow_pickle=True,
     )
-    grid_size = unpickle_with_unpickler(
-        np.load,
-        os.path.join(
+    grid_size = np.load(
+        safe_load(os.path.join(
             analysis_directory,
             Paths().grid_size_pattern.format((plate + 1)),
-        ),
+        )),
         allow_pickle=True,
     )
     return grid, grid_size

--- a/scanomatic/io/jsonizer.py
+++ b/scanomatic/io/jsonizer.py
@@ -223,7 +223,7 @@ class SOMSerializers(Enum):
     MODEL = ("__MODEL__", decode_model)
     ENUM = ("__ENUM__", decode_enum)
     ARRAY = ("__ARRAY__", decode_array)
-    DATACLASS = ("__ARRAY__", decode_dataclass)
+    DATACLASS = ("__DATACLASS__", decode_dataclass)
 
     @property
     def encoding(self) -> str:

--- a/scanomatic/io/jsonizer.py
+++ b/scanomatic/io/jsonizer.py
@@ -4,7 +4,9 @@ from enum import Enum, unique
 from typing import Any, Optional, TextIO, Type, TypeVar, Union
 from pathlib import Path
 
+from dataclasses import asdict, is_dataclass
 import numpy as np
+from scanomatic.data_processing.pheno.state import PhenotyperSettings
 from scanomatic.data_processing.phenotypes import PhenotypeDataType
 
 from scanomatic.generics.model import Model, assert_models_deeply_equal
@@ -178,11 +180,37 @@ def decode_array(obj: dict) -> np.ndarray:
         msg = "Array data missing from serialized object"
         _LOGGER.error(msg)
         raise JSONDecodingError(msg)
-
     try:
         return np.array(content, dtype=dtype)
     except TypeError:
         msg = f"Array could not be created with {dtype}"
+        _LOGGER.error(msg)
+        raise JSONDecodingError(msg)
+
+
+DATA_CLASSES: dict[str, Any] = {
+    "PhenotyperSettings": PhenotyperSettings,
+}
+
+
+def decode_dataclass(obj: dict) -> Any:
+    encoding = SOMSerializers.DATACLASS.encoding
+    try:
+        d = DATA_CLASSES[obj[encoding]]
+    except KeyError:
+        msg = f"'{obj.get(encoding)}' is not a recognized dataclass"
+        _LOGGER.error(msg)
+        raise JSONDecodingError(msg)
+    try:
+        content = obj[CONTENT]
+    except KeyError:
+        msg = "Dataclass data missing from serialized object"
+        _LOGGER.error(msg)
+        raise JSONDecodingError(msg)
+    try:
+        return d(**content)
+    except TypeError:
+        msg = f"Dataclass {encoding} could not be created from {content}"
         _LOGGER.error(msg)
         raise JSONDecodingError(msg)
 
@@ -195,6 +223,7 @@ class SOMSerializers(Enum):
     MODEL = ("__MODEL__", decode_model)
     ENUM = ("__ENUM__", decode_enum)
     ARRAY = ("__ARRAY__", decode_array)
+    DATACLASS = ("__ARRAY__", decode_dataclass)
 
     @property
     def encoding(self) -> str:
@@ -230,6 +259,15 @@ class SOMEncoder(json.JSONEncoder):
             return {
                 SOMSerializers.ARRAY.encoding: o.dtype.name,
                 CONTENT: o.tolist()
+            }
+        elif is_dataclass(o):
+            if name not in DATA_CLASSES:
+                msg = f"'{name}' not a recognized serializable dataclass"
+                _LOGGER.error(msg)
+                raise JSONEncodingError(msg)
+            return {
+                SOMSerializers.DATACLASS.encoding: name,
+                CONTENT: asdict(o),
             }
         return super().default(o)
 
@@ -301,13 +339,13 @@ def merge_into(
     needed to cover all type cases, but should not be
     in use in the code.
     """
-    if isinstance(update, list):
+    if isinstance(update, Sequence):
         _LOGGER.warning(
             f"Mergining {update} into {model} not implemented."
             " Will simply replace."
         )
         return update
-    elif isinstance(model, list):
+    elif isinstance(model, Sequence):
         ret = []
         merged = False
         for m in model:

--- a/scanomatic/io/jsonizer.py
+++ b/scanomatic/io/jsonizer.py
@@ -330,11 +330,11 @@ def merge_into(
 
 
 def dump(
-    model: Union[Model, Sequence[Model]],
+    model: Any,
     path: Union[str, Path],
-    overwrite: bool = False,
+    merge: bool = False,
 ) -> bool:
-    if overwrite:
+    if merge:
         model = merge_into(load(path), model)
     try:
         with open(path, 'w') as fh:

--- a/scanomatic/io/jsonizer.py
+++ b/scanomatic/io/jsonizer.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, TextIO, Type, TypeVar, Union
 from pathlib import Path
 
 import numpy as np
+from scanomatic.data_processing.phenotypes import PhenotypeDataType
 
 from scanomatic.generics.model import Model, assert_models_deeply_equal
 from scanomatic.io.logger import get_logger
@@ -138,6 +139,7 @@ ENUM_CLASSES: dict[str, Type[Enum]] = {
     "CULTURE_SOURCE": CULTURE_SOURCE,
     "POWER_MANAGER_TYPE": POWER_MANAGER_TYPE,
     "POWER_MODES": POWER_MODES,
+    "PhenotypeDataType": PhenotypeDataType,
 }
 
 

--- a/scanomatic/io/jsonizer.py
+++ b/scanomatic/io/jsonizer.py
@@ -188,7 +188,7 @@ def decode_array(obj: dict) -> np.ndarray:
         raise JSONDecodingError(msg)
 
 
-DATA_CLASSES: dict[str, Any] = {
+DATA_CLASSES: dict[str, Type[PhenotyperSettings]] = {
     "PhenotyperSettings": PhenotyperSettings,
 }
 
@@ -329,7 +329,7 @@ def _merge(model: Model, update: Model) -> bool:
 
 def merge_into(
     model: Optional[Union[Model, Sequence[Model]]],
-    update: Union[Sequence[Model], Model],
+    update: Any,
 ) -> Union[Sequence[Model], Model]:
     """Merges update with or into the model.
 

--- a/scanomatic/io/paths.py
+++ b/scanomatic/io/paths.py
@@ -159,7 +159,7 @@ class Paths(SingeltonOneInit):
         self.phenotypes_meta_data_original_file_patern = "meta_data_{0}.{1}"
         self.phenotypes_input_data = "curves_raw.npy"
         self.phenotypes_input_smooth = "curves_smooth.npy"
-        self.phenotypes_extraction_params = "phenotype_params.npy"
+        self.phenotypes_extraction_params = "phenotype_params.json"
         self.phenotype_times = "phenotype_times.npy"
 
         self.phenotypes_extraction_log = "phenotypes.extraction.log"

--- a/scanomatic/io/pickler.py
+++ b/scanomatic/io/pickler.py
@@ -1,5 +1,4 @@
 import os
-from pickle import load
 from typing import IO
 
 

--- a/scanomatic/io/pickler.py
+++ b/scanomatic/io/pickler.py
@@ -20,25 +20,6 @@ def safe_load(path, return_string=False):
         return fh
 
 
-def unpickle_with_unpickler(unpickler, path, *args, **kwargs):
-    """Compatibility unpickler that handles problems
-
-    This is used for
-
-    1) Dealing with errors in line-endings in data sent between different OS
-    2) Dealing with SoM refactoring import errors
-
-    Args:
-        unpickler (func): A function that unpickles a string of data
-        path (str): Path to the data to be unpickled
-        *args: Optional extra arguments for the unpickler
-        **kwargs: Opional extra keyword arguments for the unpickler
-
-    Returns: Unpickled object
-    """
-    return unpickler(safe_load(path), *args, **kwargs)
-
-
 class _RefactoringPhases:
     def __init__(self):
         """Rewrites pickled data to match refactorings"""

--- a/scanomatic/io/pickler.py
+++ b/scanomatic/io/pickler.py
@@ -3,13 +3,6 @@ from pickle import load
 from typing import IO
 
 
-def unpickle(path: str):
-    """Unpickles data safely
-    Returns: Unpickled object
-    """
-    return load(safe_load(path))
-
-
 def safe_load(path, return_string=False):
     version_compatibility = _RefactoringPhases()
     fh = SafeProxyFileObject(path, version_compatibility)

--- a/scanomatic/qc/analysis_results.py
+++ b/scanomatic/qc/analysis_results.py
@@ -13,7 +13,7 @@ from scanomatic.io.image_loading import load_colony_images_for_animation
 from scanomatic.io.logger import get_logger
 from scanomatic.io.movie_writer import MovieWriter
 from scanomatic.io.paths import Paths
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 
 _pattern = re.compile(r".*_([0-9]+)_[0-9]+_[0-9]+_[0-9]+\..*")
 _logger = get_logger("Phenotype Results QC")
@@ -45,41 +45,35 @@ def calculate_growth_curve(data_paths, blob_paths, background_paths=None):
     if background_paths is not None:
         return np.array([
             (
-                unpickle_with_unpickler(
-                    np.load,
-                    data,
+                np.load(
+                    safe_load(data),
                     allow_pickle=True,
                 )
                 - mid50_mean(
-                    unpickle_with_unpickler(
-                        np.load,
-                        data,
+                    np.load(
+                        safe_load(data),
                         allow_pickle=True,
                     )[
-                        unpickle_with_unpickler(
-                            np.load,
-                            bg,
+                        np.load(
+                            safe_load(bg),
                             allow_pickle=True,
                         )
                     ]
                 )
-            )[unpickle_with_unpickler(
-                np.load,
-                blob,
+            )[np.load(
+                safe_load(blob),
                 allow_pickle=True,
             )].sum()
             for data, blob, bg in zip(data_paths, blob_paths, background_paths)
         ])
     else:
         return np.array([
-            unpickle_with_unpickler(
-                np.load,
-                data,
+            np.load(
+                safe_load(data),
                 allow_pickle=True,
             )[
-                unpickle_with_unpickler(
-                    np.load,
-                    blob,
+                np.load(
+                    safe_load(blob),
                     allow_pickle=True,
                 )
             ].sum()
@@ -230,7 +224,10 @@ def animate_blob_detection(
 
     image_ax = fig.axes[0]
     ims = []
-    data = unpickle_with_unpickler(np.load, files[0]).astype(np.float64)
+    data = np.load(
+        safe_load(files[0]),
+        allow_pickle=True,
+    ).astype(np.float64)
     for i, ax in enumerate(fig.axes[:-1]):
         ims.append(ax.imshow(
             data,
@@ -243,9 +240,8 @@ def animate_blob_detection(
     def _plotter():
 
         for idx, index in enumerate(image_indices):
-            ims[0].set_data(unpickle_with_unpickler(
-                np.load,
-                files[idx],
+            ims[0].set_data(np.load(
+                safe_load(files[idx]),
                 allow_pickle=True,
             ))
             base_name = files[idx][:-21]
@@ -262,15 +258,13 @@ def animate_blob_detection(
                 '.blob.trash.current.npy',
                 '.blob.trash.old.npy',
             )):
-                im_data = unpickle_with_unpickler(
-                    np.load,
-                    base_name + ending,
+                im_data = np.load(
+                    safe_load(base_name + ending),
                     allow_pickle=True,
                 )
                 if im_data.ndim == 2:
-                    ims[j + 1].set_data(unpickle_with_unpickler(
-                        np.load,
-                        base_name + ending,
+                    ims[j + 1].set_data(np.load(
+                        safe_load(base_name + ending),
                         allow_pickle=True,
                     ))
 
@@ -309,9 +303,8 @@ def animate_3d_colony(
 
     image_ax, curve_ax = fig.axes
 
-    data = unpickle_with_unpickler(
-        np.load,
-        files[0],
+    data = np.load(
+        safe_load(files[0]),
         allow_pickle=True,
     )
     im = image_ax.imshow(data, interpolation='nearest', vmin=0, vmax=100)
@@ -334,9 +327,8 @@ def animate_3d_colony(
         ax3d = None
 
         for idx, index in enumerate(image_indices):
-            im.set_data(unpickle_with_unpickler(
-                np.load,
-                files[idx],
+            im.set_data(np.load(
+                safe_load(files[idx]),
                 allow_pickle=True,
             ))
 
@@ -350,9 +342,8 @@ def animate_3d_colony(
                 ),
             )
 
-            cells = unpickle_with_unpickler(
-                np.load,
-                base_name + ".image.cells.npy",
+            cells = np.load(
+                safe_load(base_name + ".image.cells.npy"),
                 allow_pickle=True,
             )
             if cells.ndim != 2:

--- a/scanomatic/qc/analysis_results.py
+++ b/scanomatic/qc/analysis_results.py
@@ -45,19 +45,43 @@ def calculate_growth_curve(data_paths, blob_paths, background_paths=None):
     if background_paths is not None:
         return np.array([
             (
-                unpickle_with_unpickler(np.load, data)
+                unpickle_with_unpickler(
+                    np.load,
+                    data,
+                    allow_pickle=True,
+                )
                 - mid50_mean(
-                    unpickle_with_unpickler(np.load, data)[
-                        unpickle_with_unpickler(np.load, bg)
+                    unpickle_with_unpickler(
+                        np.load,
+                        data,
+                        allow_pickle=True,
+                    )[
+                        unpickle_with_unpickler(
+                            np.load,
+                            bg,
+                            allow_pickle=True,
+                        )
                     ]
                 )
-            )[unpickle_with_unpickler(np.load, blob)].sum()
+            )[unpickle_with_unpickler(
+                np.load,
+                blob,
+                allow_pickle=True,
+            )].sum()
             for data, blob, bg in zip(data_paths, blob_paths, background_paths)
         ])
     else:
         return np.array([
-            unpickle_with_unpickler(np.load, data)[
-                unpickle_with_unpickler(np.load, blob)
+            unpickle_with_unpickler(
+                np.load,
+                data,
+                allow_pickle=True,
+            )[
+                unpickle_with_unpickler(
+                    np.load,
+                    blob,
+                    allow_pickle=True,
+                )
             ].sum()
             for data, blob in zip(data_paths, blob_paths)
         ])
@@ -219,7 +243,11 @@ def animate_blob_detection(
     def _plotter():
 
         for idx, index in enumerate(image_indices):
-            ims[0].set_data(unpickle_with_unpickler(np.load, files[idx]))
+            ims[0].set_data(unpickle_with_unpickler(
+                np.load,
+                files[idx],
+                allow_pickle=True,
+            ))
             base_name = files[idx][:-21]
             image_ax.set_title(
                 "Image (t={0:.1f}h)".format(
@@ -234,11 +262,16 @@ def animate_blob_detection(
                 '.blob.trash.current.npy',
                 '.blob.trash.old.npy',
             )):
-                im_data = unpickle_with_unpickler(np.load, base_name + ending)
+                im_data = unpickle_with_unpickler(
+                    np.load,
+                    base_name + ending,
+                    allow_pickle=True,
+                )
                 if im_data.ndim == 2:
                     ims[j + 1].set_data(unpickle_with_unpickler(
                         np.load,
                         base_name + ending,
+                        allow_pickle=True,
                     ))
 
             set_axvspan_width(polygon, curve_times[idx])
@@ -276,7 +309,11 @@ def animate_3d_colony(
 
     image_ax, curve_ax = fig.axes
 
-    data = unpickle_with_unpickler(np.load, files[0])
+    data = unpickle_with_unpickler(
+        np.load,
+        files[0],
+        allow_pickle=True,
+    )
     im = image_ax.imshow(data, interpolation='nearest', vmin=0, vmax=100)
 
     coords_x, coords_y = np.mgrid[0:data.shape[0], 0:data.shape[1]]
@@ -297,7 +334,11 @@ def animate_3d_colony(
         ax3d = None
 
         for idx, index in enumerate(image_indices):
-            im.set_data(unpickle_with_unpickler(np.load, files[idx]))
+            im.set_data(unpickle_with_unpickler(
+                np.load,
+                files[idx],
+                allow_pickle=True,
+            ))
 
             # Added suffix length too
             base_name = files[idx][:-(10 + 11)]
@@ -310,7 +351,9 @@ def animate_3d_colony(
             )
 
             cells = unpickle_with_unpickler(
-                np.load, base_name + ".image.cells.npy",
+                np.load,
+                base_name + ".image.cells.npy",
+                allow_pickle=True,
             )
             if cells.ndim != 2:
                 cells = np.zeros_like(coords_y)

--- a/scanomatic/server/phenotype_effector.py
+++ b/scanomatic/server/phenotype_effector.py
@@ -71,7 +71,7 @@ class PhenotypeExtractionEffector(proc_effector.ProcessEffector):
                     self._feature_job.analysis_directory,
                     paths.Paths().phenotypes_extraction_instructions,
                 ),
-                overwrite=True,
+                merge=True,
             )
         else:
             self._logger.warning("Can't setup, instructions don't validate")

--- a/scanomatic/ui_server/analysis_api.py
+++ b/scanomatic/ui_server/analysis_api.py
@@ -1,6 +1,7 @@
 import os
 from glob import glob
 from itertools import chain, product
+from typing import Optional
 
 from flask import jsonify, request
 
@@ -48,8 +49,8 @@ def add_routes(app):
     @app.route("/api/analysis/image/grid", methods=['POST'])
     def get_gridding_image():
 
-        pinning_format = request.values.get_list('pinning_format')
-        correction = request.values.getlist('gridding_correction')
+        pinning_format = request.values.getlist('pinning_format')
+        correction: Optional[list[str]] = request.values.getlist('gridding_correction')
         if not correction:
             correction = None
         im = get_image_data_as_array(request.files.get('image'))

--- a/scanomatic/ui_server/analysis_api.py
+++ b/scanomatic/ui_server/analysis_api.py
@@ -50,7 +50,9 @@ def add_routes(app):
     def get_gridding_image():
 
         pinning_format = request.values.getlist('pinning_format')
-        correction: Optional[list[str]] = request.values.getlist('gridding_correction')
+        correction: Optional[list[str]] = request.values.getlist(
+            'gridding_correction',
+        )
         if not correction:
             correction = None
         im = get_image_data_as_array(request.files.get('image'))

--- a/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
@@ -204,7 +204,6 @@ export function DrawPlate(container, data, growthMetaData, plateMetaData, phenot
       class: 'PlateHeatMap',
     });
 
-
   addSelectionHandling(grid);
   addSymbolsToSVG(grid);
 
@@ -409,7 +408,7 @@ d3.scanomatic.plateHeatmap = () => {
     function setShapes(node) {
       // ok metadata
       node
-        .filter(d => d.metaType === plateMetaDataType.OK)
+        .filter((d) => d.metaType === plateMetaDataType.OK)
         .append('circle')
         .attr({
           class: 'plateWell OK',
@@ -419,16 +418,16 @@ d3.scanomatic.plateHeatmap = () => {
           r: cellRadius,
           cy(d) { return d.celStartY + cellRadius; },
           cx(d) { return d.celStartX + cellRadius; },
-          'data-col': d => d.col,
-          'data-meta-gt': d => d.metaGT,
-          'data-meta-gtWhen': d => d.metaGtWhen,
-          'data-meta-yield': d => d.metaYield,
-          'data-meta-type': d => d.metaType,
+          'data-col': (d) => d.col,
+          'data-meta-gt': (d) => d.metaGT,
+          'data-meta-gtWhen': (d) => d.metaGtWhen,
+          'data-meta-yield': (d) => d.metaYield,
+          'data-meta-type': (d) => d.metaType,
         });
 
       // bad metadata
       node
-        .filter(d => d.metaType !== plateMetaDataType.OK)
+        .filter((d) => d.metaType !== plateMetaDataType.OK)
         .append('rect')
         .attr({
           class: 'plateWell Marked',
@@ -439,22 +438,22 @@ d3.scanomatic.plateHeatmap = () => {
           x(d) { return d.celStartX; },
           width: heatMapCelWidth,
           height: heatMapCelHeight,
-          'data-col': d => d.col,
-          'data-meta-gt': d => d.metaGT,
-          'data-meta-gtWhen': d => d.metaGtWhen,
-          'data-meta-yield': d => d.metaYield,
-          'data-meta-type': d => d.metaType,
+          'data-col': (d) => d.col,
+          'data-meta-gt': (d) => d.metaGT,
+          'data-meta-gtWhen': (d) => d.metaGtWhen,
+          'data-meta-yield': (d) => d.metaYield,
+          'data-meta-type': (d) => d.metaType,
         });
     }
 
     function setSymbols(node) {
       // Empty
       node
-        .filter(d => d.metaType === plateMetaDataType.Empty)
+        .filter((d) => d.metaType === plateMetaDataType.Empty)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY - 0.8; },
           width: cellRadius * 3,
@@ -463,11 +462,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // UndecidedProblem
       node
-        .filter(d => d.metaType === plateMetaDataType.UndecidedProblem)
+        .filter((d) => d.metaType === plateMetaDataType.UndecidedProblem)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY; },
           width: cellRadius * 3,
@@ -476,11 +475,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // BadData
       node
-        .filter(d => d.metaType === plateMetaDataType.BadData)
+        .filter((d) => d.metaType === plateMetaDataType.BadData)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY; },
           width: cellRadius * 3,
@@ -489,11 +488,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // NoGrowth
       node
-        .filter(d => d.metaType === plateMetaDataType.NoGrowth)
+        .filter((d) => d.metaType === plateMetaDataType.NoGrowth)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 1; },
           y(d) { return d.celStartY; },
           width: cellRadius * 2.5,
@@ -550,7 +549,7 @@ d3.scanomatic.plateHeatmap = () => {
     }
 
     function onMouseOut(node) {
-      node.select('.plateWell').attr('fill', d => getValidColor(d.phenotype, d.metaType));
+      node.select('.plateWell').attr('fill', (d) => getValidColor(d.phenotype, d.metaType));
       node.select('.plateWellSymbol').attr('fill', 'black');
 
       toolTipDiv.transition()
@@ -684,11 +683,11 @@ d3.scanomatic.plateHeatmap = () => {
     function addSymbols(nodes) {
       // Empty
       nodes
-        .filter(d => d.metaType === plateMetaDataType.Empty)
+        .filter((d) => d.metaType === plateMetaDataType.Empty)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY - 0.8; },
           width: cellRadius * 3,
@@ -697,11 +696,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // UndecidedProblem
       nodes
-        .filter(d => d.metaType === plateMetaDataType.UndecidedProblem)
+        .filter((d) => d.metaType === plateMetaDataType.UndecidedProblem)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY; },
           width: cellRadius * 3,
@@ -710,11 +709,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // BadData
       nodes
-        .filter(d => d.metaType === plateMetaDataType.BadData)
+        .filter((d) => d.metaType === plateMetaDataType.BadData)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 2; },
           y(d) { return d.celStartY; },
           width: cellRadius * 3,
@@ -723,11 +722,11 @@ d3.scanomatic.plateHeatmap = () => {
 
       // NoGrowth
       nodes
-        .filter(d => d.metaType === plateMetaDataType.NoGrowth)
+        .filter((d) => d.metaType === plateMetaDataType.NoGrowth)
         .append('use')
         .attr({
           class: 'plateWellSymbol',
-          'xlink:href': d => `#${getValidSymbol(d.metaType)}`,
+          'xlink:href': (d) => `#${getValidSymbol(d.metaType)}`,
           x(d) { return d.celStartX - 1; },
           y(d) { return d.celStartY; },
           width: cellRadius * 2.5,
@@ -738,7 +737,7 @@ d3.scanomatic.plateHeatmap = () => {
     function addShapes(nodes) {
       // ok metadata
       nodes
-        .filter(d => d.metaType === plateMetaDataType.OK)
+        .filter((d) => d.metaType === plateMetaDataType.OK)
         .append('circle')
         .attr({
           class: 'plateWell OK',
@@ -748,16 +747,16 @@ d3.scanomatic.plateHeatmap = () => {
           r: cellRadius,
           cy(d) { return d.celStartY + cellRadius; },
           cx(d) { return d.celStartX + cellRadius; },
-          'data-col': d => d.col,
-          'data-meta-gt': d => d.metaGT,
-          'data-meta-gtWhen': d => d.metaGtWhen,
-          'data-meta-yield': d => d.metaYield,
-          'data-meta-type': d => d.metaType,
+          'data-col': (d) => d.col,
+          'data-meta-gt': (d) => d.metaGT,
+          'data-meta-gtWhen': (d) => d.metaGtWhen,
+          'data-meta-yield': (d) => d.metaYield,
+          'data-meta-type': (d) => d.metaType,
         });
 
       // bad metadata
       nodes
-        .filter(d => d.metaType !== plateMetaDataType.OK)
+        .filter((d) => d.metaType !== plateMetaDataType.OK)
         .append('rect')
         .attr({
           class: 'plateWell Marked',
@@ -768,14 +767,13 @@ d3.scanomatic.plateHeatmap = () => {
           x(d) { return d.celStartX; },
           width: heatMapCelWidth,
           height: heatMapCelHeight,
-          'data-col': d => d.col,
-          'data-meta-gt': d => d.metaGT,
-          'data-meta-gtWhen': d => d.metaGtWhen,
-          'data-meta-yield': d => d.metaYield,
-          'data-meta-type': d => d.metaType,
+          'data-col': (d) => d.col,
+          'data-meta-gt': (d) => d.metaGT,
+          'data-meta-gtWhen': (d) => d.metaGtWhen,
+          'data-meta-yield': (d) => d.metaYield,
+          'data-meta-type': (d) => d.metaType,
         });
     }
-
 
     dispatch2.on('setExp', setExperiment);
     dispatch2.on('reDrawExp', reDrawExperiment);
@@ -788,7 +786,7 @@ d3.scanomatic.plateHeatmap = () => {
       });
 
     const nodes = gHeatMap.selectAll('nodes')
-      .data(d => d)
+      .data((d) => d)
       .enter()
       .append('g')
       .attr('class', 'expNode')

--- a/scanomatic/util/analysis.py
+++ b/scanomatic/util/analysis.py
@@ -8,7 +8,7 @@ from scanomatic.image_analysis.image_basics import load_image_to_numpy
 from scanomatic.io.jsonizer import load
 from scanomatic.io.logger import get_logger
 from scanomatic.io.paths import Paths
-from scanomatic.io.pickler import unpickle_with_unpickler
+from scanomatic.io.pickler import safe_load
 from scanomatic.models.compile_project_model import CompileImageAnalysisModel
 
 _logger = get_logger("Analysis Utils")
@@ -95,9 +95,8 @@ def produce_grid_images(
         grid_path = os.path.join(
             path, Paths().grid_pattern.format(plate.index))
         try:
-            grid = unpickle_with_unpickler(
-                np.load,
-                grid_path,
+            grid = np.load(
+                safe_load(grid_path),
                 allow_pickle=True,
             )
         except IOError:

--- a/scanomatic/util/analysis.py
+++ b/scanomatic/util/analysis.py
@@ -95,7 +95,11 @@ def produce_grid_images(
         grid_path = os.path.join(
             path, Paths().grid_pattern.format(plate.index))
         try:
-            grid = unpickle_with_unpickler(np.load, grid_path)
+            grid = unpickle_with_unpickler(
+                np.load,
+                grid_path,
+                allow_pickle=True,
+            )
         except IOError:
             _logger.warning("Could not find any grid: " + grid_path)
             grid = None

--- a/scanomatic/util/analysis.py
+++ b/scanomatic/util/analysis.py
@@ -60,12 +60,12 @@ def produce_grid_images(
         )
     )
 
-    compilation: list[CompileImageAnalysisModel] = load(compilation)
+    compilation_list: list[CompileImageAnalysisModel] = load(compilation)
 
-    image_path = compilation[-1].image.path
-    all_plates = compilation[-1].fixture.plates
+    image_path = compilation_list[-1].image.path
+    all_plates = compilation_list[-1].fixture.plates
     if image is not None:
-        for c in compilation:
+        for c in compilation_list:
             if os.path.basename(c.image.path) == os.path.basename(image):
                 image_path = c.image.path
                 all_plates = c.fixture.plates

--- a/scanomatic/util/project.py
+++ b/scanomatic/util/project.py
@@ -106,7 +106,7 @@ def rename_scan_instructions(new_name, old_name=None, **model_updates):
             dump(
                 m,
                 destination,
-                overwrite=True,
+                merge=True,
             )
 
             _logger.info("Updated the contents of {0}".format(destination))

--- a/tests/unit/data_processing/pheno/test_state.py
+++ b/tests/unit/data_processing/pheno/test_state.py
@@ -42,33 +42,6 @@ class TestPhenotyperSettings:
         with pytest.raises(AssertionError):
             PhenotyperSettings(4, 1.0, 3, None, 2.0, 3.0)
 
-    def test_serialized_no_inclusion(self):
-        assert PhenotyperSettings(5, 1.0, 3, None, 2.0, 3.0).serialized() == [
-            5,
-            1.0,
-            3,
-            None,
-            2.0,
-            3.0,
-        ]
-
-    def test_serialized_with_inclusion(self):
-        assert PhenotyperSettings(
-            5,
-            1.0,
-            3,
-            PhenotypeDataType.All,
-            2.0,
-            3.0,
-        ).serialized() == [
-            5,
-            1.0,
-            3,
-            "All",
-            2.0,
-            3.0,
-        ]
-
 
 class TestPhenotyperState:
     @pytest.fixture

--- a/tests/unit/io/fixtures/phenotype_params.json
+++ b/tests/unit/io/fixtures/phenotype_params.json
@@ -1,0 +1,14 @@
+{
+  "__DATACLASS__": "PhenotyperSettings",
+  "__CONTENT__": {
+    "no_growth_pop_doublings_threshold": 1.0,
+    "phenotypes_inclusion": {
+      "__CONTENT__": "Trusted",
+      "__ENUM__": "PhenotypeDataType"
+    },
+    "median_kernel_size": 5,
+    "linear_regression_size": 5,
+    "no_growth_monotonicity_threshold": 0.6,
+    "gaussian_filter_sigma": 1.5
+  }
+}

--- a/tests/unit/io/fixtures/phenotype_params.no-optional.json
+++ b/tests/unit/io/fixtures/phenotype_params.no-optional.json
@@ -1,0 +1,8 @@
+{
+  "__DATACLASS__": "PhenotyperSettings",
+  "__CONTENT__": {
+    "median_kernel_size": 5,
+    "linear_regression_size": 5,
+    "gaussian_filter_sigma": 1.5
+  }
+}

--- a/tests/unit/io/test_jsonizer.py
+++ b/tests/unit/io/test_jsonizer.py
@@ -6,6 +6,8 @@ from typing import Optional, Type, Union
 
 import numpy as np
 import pytest
+from scanomatic.data_processing.pheno.state import PhenotyperSettings
+from scanomatic.data_processing.phenotypes import PhenotypeDataType
 
 from scanomatic.generics.model import Model, assert_models_deeply_equal
 from scanomatic.io import jsonizer
@@ -161,7 +163,7 @@ def test_preserves_arrays(arr: np.ndarray):
 
 
 def test_preserves_object_array():
-    arr = np.array([None, 4, np.array([2, 1])])
+    arr = np.array([None, 4, np.array([2, 1])], dtype=object)
     arr2 = jsonizer.loads(jsonizer.dumps(arr))
     assert arr2.dtype == arr.dtype
     assert arr[0] is arr2[0]
@@ -174,6 +176,7 @@ def test_preserves_object_array():
     COMPARTMENTS.Blob,
     VALUES.Pixels,
     MEASURES.Centroid,
+    PhenotypeDataType.Trusted,
 ))
 def test_preserves_enums(test_enum: Enum):
     assert jsonizer.loads(jsonizer.dumps(test_enum)) is test_enum
@@ -212,6 +215,15 @@ def test_raises_on_unkown_model_loading(s: str):
         jsonizer.loads(s)
 
 
+@pytest.mark.parametrize('s', (
+    '{"__DATACLASS__": "DataClass", "__CONTENT__": {}}',
+    '{"__DATACLASS__": "DataClass", "__CONTENT__": null}',
+))
+def test_raises_on_unkown_dataclass_loading(s: str):
+    with pytest.raises(jsonizer.JSONDecodingError):
+        jsonizer.loads(s)
+
+
 @pytest.fixture
 def fixture() -> FixtureModel:
     return FixtureFactory.create(
@@ -239,6 +251,7 @@ def test_copy_makes_new_object(fixture: FixtureModel):
     ('analysis.model', AnalysisModel),
     ('analysis.model-list', list),
     ('not-a-file', None),
+    ('phenotype_params.json', PhenotyperSettings),
 ))
 def test_load(filename: str, expect: Optional[Type]):
     data = jsonizer.load(
@@ -254,6 +267,7 @@ def test_load(filename: str, expect: Optional[Type]):
     ('analysis.model', AnalysisModel),
     ('analysis.model-list', AnalysisModel),
     ('not-a-file', None),
+    ('phenotype_params.json', PhenotyperSettings),
 ))
 def test_load_first(filename: str, expect: Optional[Type]):
     data = jsonizer.load_first(

--- a/tests/unit/io/test_jsonizer.py
+++ b/tests/unit/io/test_jsonizer.py
@@ -6,9 +6,10 @@ from typing import Optional, Type, Union
 
 import numpy as np
 import pytest
+from dataclasses import asdict
+
 from scanomatic.data_processing.pheno.state import PhenotyperSettings
 from scanomatic.data_processing.phenotypes import PhenotypeDataType
-
 from scanomatic.generics.model import Model, assert_models_deeply_equal
 from scanomatic.io import jsonizer
 from scanomatic.io.power_manager import POWER_MANAGER_TYPE, POWER_MODES
@@ -182,6 +183,17 @@ def test_preserves_enums(test_enum: Enum):
     assert jsonizer.loads(jsonizer.dumps(test_enum)) is test_enum
 
 
+@pytest.mark.parametrize("test_dataclass", (
+    PhenotyperSettings(1, 2, 3),
+    PhenotyperSettings(1, 2, 3, PhenotypeDataType.Phases, 4, 5),
+))
+def test_preserves_dataclasses(test_dataclass):
+    assert (
+        asdict(jsonizer.loads(jsonizer.dumps(test_dataclass)))
+        == asdict(test_dataclass)
+    )
+
+
 def test_raises_on_unknown_enum_dumping():
     class E(Enum):
         A = 1
@@ -252,6 +264,7 @@ def test_copy_makes_new_object(fixture: FixtureModel):
     ('analysis.model-list', list),
     ('not-a-file', None),
     ('phenotype_params.json', PhenotyperSettings),
+    ('phenotype_params.no-optional.json', PhenotyperSettings),
 ))
 def test_load(filename: str, expect: Optional[Type]):
     data = jsonizer.load(


### PR DESCRIPTION
This removes the node dependency `fix`, which seems to have been installed by mistake: https://www.npmjs.com/package/fix

Removing this allows us to update to a safe version of log4js, as well as removing at least one other unsafe dependency. This may also make it possible to further upgrade e.g. karma