### PR TITLE
remove fix and audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-plugin-jsx-a11y": "^6.0.2",
         "eslint-plugin-react": "^7.5.1",
         "file-loader": "^6.2.0",
-        "fix": "^0.0.6",
         "jasmine-ajax": "^4.0.0",
         "jasmine-core": "^4.0.0",
         "karma": "^6.3.12",
@@ -4873,20 +4872,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/fix": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/fix/-/fix-0.0.6.tgz",
-      "integrity": "sha1-B+WTonQU3cSG7lLVD5yOCYhaAwU=",
-      "dev": true,
-      "dependencies": {
-        "pipe": "0.0.2",
-        "underscore": "1.1.6",
-        "underscore.string": "1.1.4"
-      },
-      "engines": {
-        "node": ">=0.4.8"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -8071,15 +8056,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pipe": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pipe/-/pipe-0.0.2.tgz",
-      "integrity": "sha1-oW/m/AGddb2YfEkopn4eUOT1tE8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.8"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -10512,27 +10488,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-      "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/underscore.string": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.4.tgz",
-      "integrity": "sha1-m+BrI7jj2ZbqICD5mEICBp497hI=",
-      "dev": true,
-      "dependencies": {
-        "underscore": "1.1.6"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/union-value": {
@@ -15976,17 +15931,6 @@
         "locate-path": "^2.0.0"
       }
     },
-    "fix": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/fix/-/fix-0.0.6.tgz",
-      "integrity": "sha1-B+WTonQU3cSG7lLVD5yOCYhaAwU=",
-      "dev": true,
-      "requires": {
-        "pipe": "0.0.2",
-        "underscore": "1.1.6",
-        "underscore.string": "1.1.4"
-      }
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -18440,12 +18384,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pipe": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pipe/-/pipe-0.0.2.tgz",
-      "integrity": "sha1-oW/m/AGddb2YfEkopn4eUOT1tE8=",
-      "dev": true
-    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -20369,21 +20307,6 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
-      }
-    },
-    "underscore": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.6.tgz",
-      "integrity": "sha1-aGjaG91y11KFvgtOUPIo5w0AGiw=",
-      "dev": true
-    },
-    "underscore.string": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-1.1.4.tgz",
-      "integrity": "sha1-m+BrI7jj2ZbqICD5mEICBp497hI=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.1.6"
       }
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "spin": "^0.0.1"
       },
       "devDependencies": {
-        "audit": "^0.0.6",
         "babel-core": "^6.26.0",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^7.1.2",
@@ -1309,15 +1308,6 @@
       },
       "engines": {
         "node": ">= 4.5.0"
-      }
-    },
-    "node_modules/audit": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/audit/-/audit-0.0.6.tgz",
-      "integrity": "sha1-/vF92Erx3NKlYz/UbTsa3LCEvzs=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.5.0"
       }
     },
     "node_modules/axe-core": {
@@ -12950,12 +12940,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
-    },
-    "audit": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/audit/-/audit-0.0.6.tgz",
-      "integrity": "sha1-/vF92Erx3NKlYz/UbTsa3LCEvzs=",
       "dev": true
     },
     "axe-core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "lint": "eslint --ext mjs,jsx,js scanomatic/ui_server_data/js/ccc scanomatic/ui_server_data/js/tests"
   },
   "devDependencies": {
-    "audit": "^0.0.6",
     "babel-core": "^6.26.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
     "file-loader": "^6.2.0",
-    "fix": "^0.0.6",
     "jasmine-ajax": "^4.0.0",
     "jasmine-core": "^4.0.0",
     "karma": "^6.3.12",


### PR DESCRIPTION
This removes the node dependencies `fix` and `audit`, which seem to have been installed by mistake:
- https://www.npmjs.com/package/fix
- https://www.npmjs.com/package/audit

*N.B.:* `npm audit` `npm audit fix` and `npm run lint --fix` should still work! These packages have nothing to do with these functionalities!

Removing this removes at least one other unsafe dependency. This may also make it possible to further upgrade some of our dependencies. I thought it would also update log4js to a safe version but was mistaken.

```console
$ npm outdated
Package                Current   Wanted  Latest  Location                            Depended by
babel-loader             7.1.5    7.1.5   8.2.3  node_modules/babel-loader           scanomatic-standalone
babel-plugin-istanbul    4.1.6    4.1.6   6.1.1  node_modules/babel-plugin-istanbul  scanomatic-standalone
bootstrap                3.4.1    3.4.1   5.1.3  node_modules/bootstrap              scanomatic-standalone
c3                      0.4.24   0.4.24  0.7.20  node_modules/c3                     scanomatic-standalone
css-loader               5.2.7    5.2.7   6.5.1  node_modules/css-loader             scanomatic-standalone
d3                      3.5.17   3.5.17   7.3.0  node_modules/d3                     scanomatic-standalone
eslint                  7.32.0   7.32.0   8.7.0  node_modules/eslint                 scanomatic-standalone
karma-webpack           2.0.13   2.0.13   5.0.0  node_modules/karma-webpack          scanomatic-standalone
react                  16.14.0  16.14.0  17.0.2  node_modules/react                  scanomatic-standalone
react-dom              16.14.0  16.14.0  17.0.2  node_modules/react-dom              scanomatic-standalone
react-test-renderer    16.14.0  16.14.0  17.0.2  node_modules/react-test-renderer    scanomatic-standalone
style-loader             2.0.0    2.0.0   3.3.1  node_modules/style-loader           scanomatic-standalone
webpack                 4.46.0   4.46.0  5.67.0  node_modules/webpack                scanomatic-standalone

```