### PR TITLE
Validate compile project

### DIFF
--- a/scanomatic/image_analysis/first_pass.py
+++ b/scanomatic/image_analysis/first_pass.py
@@ -1,5 +1,6 @@
 from typing import Any
 from scanomatic.image_analysis.first_pass_image import FixtureImage
+from scanomatic.io import jsonizer
 from scanomatic.io.fixtures import FixtureSettings
 from scanomatic.io.logger import get_logger
 from scanomatic.models.compile_project_model import (
@@ -9,7 +10,6 @@ from scanomatic.models.compile_project_model import (
 from scanomatic.models.factories.compile_project_factory import (
     CompileImageAnalysisFactory
 )
-from scanomatic.models.factories.fixture_factories import FixtureFactory
 
 _logger = get_logger("1st Pass Analysis")
 
@@ -25,7 +25,7 @@ def analyse(
 ) -> CompileImageAnalysisModel:
     compile_analysis_model = CompileImageAnalysisFactory.create(
         image=compile_image_model,
-        fixture=FixtureFactory.copy(fixture_settings.model),
+        fixture=jsonizer.copy(fixture_settings.model),
     )
 
     fixture_image = FixtureImage(fixture=fixture_settings)

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -433,7 +433,7 @@ class FixtureImage:
             current_model.grayscale.section_values = detect_grayscale(
                 grayscale_im,
                 grayscale_config,
-            )[1]
+            )
 
         except GrayscaleError:
             self._logger.warning("Failed analysing grayscale")

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -425,7 +425,10 @@ class FixtureImage:
     def analyse_grayscale(self) -> None:
         current_model = self["current"].model
         try:
-            grayscale_im = get_grayscale_im_section(self.im, current_model.grayscale)
+            grayscale_im = get_grayscale_im_section(
+                self.im,
+                current_model.grayscale,
+            )
             grayscale_config = get_grayscale(current_model.grayscale.name)
             current_model.grayscale.section_values = detect_grayscale(
                 grayscale_im,

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -5,6 +5,7 @@ from typing import Any, Union
 import numpy as np
 
 from scanomatic.data_processing.calibration import get_image_json_from_ccc
+from scanomatic.image_analysis.grayscale import get_grayscale
 from scanomatic.io.ccc_data import CCCImage
 from scanomatic.io.fixtures import Fixtures, FixtureSettings
 from scanomatic.io.logger import get_logger
@@ -15,6 +16,7 @@ from scanomatic.models.fixture_models import (
 )
 from scanomatic.image_analysis.grayscale_detection import (
     detect_grayscale,
+    get_grayscale_im_section,
 )
 from scanomatic.image_analysis.exceptions import GrayscaleError
 
@@ -423,9 +425,11 @@ class FixtureImage:
     def analyse_grayscale(self) -> None:
         current_model = self["current"].model
         try:
+            grayscale_im = get_grayscale_im_section(self.im, current_model.grayscale)
+            grayscale_config = get_grayscale(current_model.grayscale.name)
             current_model.grayscale.section_values = detect_grayscale(
-                self.im,
-                current_model.grayscale,
+                grayscale_im,
+                grayscale_config,
             )[1]
 
         except GrayscaleError:

--- a/scanomatic/image_analysis/first_pass_image.py
+++ b/scanomatic/image_analysis/first_pass_image.py
@@ -6,10 +6,10 @@ import numpy as np
 
 from scanomatic.data_processing.calibration import get_image_json_from_ccc
 from scanomatic.image_analysis.grayscale import get_grayscale
+from scanomatic.io import jsonizer
 from scanomatic.io.ccc_data import CCCImage
 from scanomatic.io.fixtures import Fixtures, FixtureSettings
 from scanomatic.io.logger import get_logger
-from scanomatic.models.factories.fixture_factories import FixturePlateFactory
 from scanomatic.models.fixture_models import (
     FixturePlateModel,
     GrayScaleAreaModel
@@ -509,7 +509,7 @@ class FixtureImage:
         )
 
         current_model.plates = type(current_model.plates)(
-            FixturePlateFactory.copy(plate) for plate in ref_model.plates
+            jsonizer.copy(plate) for plate in ref_model.plates
         )
 
         for plate in current_model.plates:

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, cast
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
@@ -187,15 +187,13 @@ def get_grayscale_im_section(
 
 
 def detect_grayscale(
-    image: np.ndarray,
-    grayscale: GrayScaleAreaModel,
+    grayscale_image: np.ndarray,
+    grayscale: Grayscale,
     debug: bool = False,
 ) -> tuple[np.ndarray, list[float]]:
     global DEBUG_DETECTION
 
-    grayscale_im = get_grayscale_im_section(image, grayscale)
-
-    im_ortho = get_ortho_trimmed_slice(grayscale_im, grayscale)
+    im_ortho = get_ortho_trimmed_slice(grayscale_image, grayscale)
     if not im_ortho.size:
         raise GrayscaleError("Failed to get orthogonal trimmed slice")
     im_para = get_para_trimmed_slice(im_ortho, grayscale)
@@ -567,4 +565,4 @@ def find_grayscale_locations(
             gray_scale,
         )
 
-    return grayscale_segment_centers, gray_scale
+    return cast(np.ndarray, grayscale_segment_centers), gray_scale

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, cast
+from typing import Optional
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided

--- a/scanomatic/image_analysis/grayscale_detection.py
+++ b/scanomatic/image_analysis/grayscale_detection.py
@@ -190,7 +190,7 @@ def detect_grayscale(
     grayscale_image: np.ndarray,
     grayscale: Grayscale,
     debug: bool = False,
-) -> tuple[np.ndarray, list[float]]:
+) -> list[float]:
     global DEBUG_DETECTION
 
     im_ortho = get_ortho_trimmed_slice(grayscale_image, grayscale)
@@ -249,7 +249,7 @@ def is_valid_grayscale(
 def find_grayscale_locations(
     im_trimmed: np.ndarray,
     grayscale: Grayscale,
-) -> tuple[np.ndarray, list[float]]:
+) -> list[float]:
     gray_scale: list[float] = []
     grayscale_segment_centers: Optional[np.ndarray] = None
 
@@ -565,4 +565,4 @@ def find_grayscale_locations(
             gray_scale,
         )
 
-    return cast(np.ndarray, grayscale_segment_centers), gray_scale
+    return gray_scale

--- a/scanomatic/image_analysis/grid_cell_extra.py
+++ b/scanomatic/image_analysis/grid_cell_extra.py
@@ -813,7 +813,7 @@ class Blob(CellItem):
                 None,
             )
 
-        self.filter_array[(x_slice, y_slice)] += (
+        self.filter_array[(x_slice, y_slice)] |= (
             stencil[(x_stencil_slice, y_stencil_slice)]
         )
 

--- a/scanomatic/image_analysis/grid_cell_extra.py
+++ b/scanomatic/image_analysis/grid_cell_extra.py
@@ -602,7 +602,7 @@ class Blob(CellItem):
             if self.filter_array.sum() == 0:
                 self.filter_array = self.old_filter.copy()
 
-            blob_diff = (np.abs(self.old_filter - self.filter_array)).sum()
+            blob_diff = (np.abs(self.old_filter ^ self.filter_array)).sum()
 
             sqrt_of_oldsum = self.old_filter.sum() ** 0.5
 
@@ -625,59 +625,59 @@ class Blob(CellItem):
 
                         diff_filter = (
                             self.old_filter[dim_1_offset:, dim_2_offset:]
-                            - self.filter_array[:-dim_1_offset, :-dim_2_offset]
+                            ^ self.filter_array[:-dim_1_offset, :-dim_2_offset]
                         )
 
                     elif dim_1_offset < 0 and dim_2_offset < 0:
 
                         diff_filter = (
                             self.old_filter[: dim_1_offset, : dim_2_offset]
-                            - self.filter_array[-dim_1_offset:, -dim_2_offset:]
+                            ^ self.filter_array[-dim_1_offset:, -dim_2_offset:]
                         )
 
                     elif dim_1_offset > 0 > dim_2_offset:
 
                         diff_filter = (
                             self.old_filter[dim_1_offset:, : dim_2_offset]
-                            - self.filter_array[:-dim_1_offset, -dim_2_offset:]
+                            ^ self.filter_array[:-dim_1_offset, -dim_2_offset:]
                         )
 
                     elif dim_1_offset < 0 < dim_2_offset:
 
                         diff_filter = (
                             self.old_filter[: dim_1_offset, dim_2_offset:]
-                            - self.filter_array[-dim_1_offset:, :-dim_2_offset]
+                            ^ self.filter_array[-dim_1_offset:, :-dim_2_offset]
                         )
 
                     elif dim_1_offset == 0 and dim_2_offset < 0:
 
                         diff_filter = (
                             self.old_filter[:, : dim_2_offset]
-                            - self.filter_array[:, -dim_2_offset:]
+                            ^ self.filter_array[:, -dim_2_offset:]
                         )
 
                     elif dim_1_offset == 0 and dim_2_offset > 0:
 
                         diff_filter = (
                             self.old_filter[:, dim_2_offset:]
-                            - self.filter_array[:, :-dim_2_offset]
+                            ^ self.filter_array[:, :-dim_2_offset]
                         )
 
                     elif dim_1_offset < 0 and dim_2_offset == 0:
 
                         diff_filter = (
                             self.old_filter[: dim_1_offset, :]
-                            - self.filter_array[-dim_1_offset:, :]
+                            ^ self.filter_array[-dim_1_offset:, :]
                         )
 
                     elif dim_1_offset > 0 == dim_2_offset:
                         diff_filter = (
                             self.old_filter[dim_1_offset:, :]
-                            - self.filter_array[:-dim_1_offset, :]
+                            ^ self.filter_array[:-dim_1_offset, :]
                         )
 
                     else:
-                        diff_filter = self.old_filter - self.filter_array
+                        diff_filter = self.old_filter ^ self.filter_array
 
                     blob_diff = diff_filter.sum()
 

--- a/scanomatic/image_analysis/grid_cell_extra.py
+++ b/scanomatic/image_analysis/grid_cell_extra.py
@@ -602,7 +602,7 @@ class Blob(CellItem):
             if self.filter_array.sum() == 0:
                 self.filter_array = self.old_filter.copy()
 
-            blob_diff = (np.abs(self.old_filter ^ self.filter_array)).sum()
+            blob_diff = (self.old_filter ^ self.filter_array).sum()
 
             sqrt_of_oldsum = self.old_filter.sum() ** 0.5
 

--- a/scanomatic/server/compile_effector.py
+++ b/scanomatic/server/compile_effector.py
@@ -250,7 +250,7 @@ class CompileProjectEffector(proc_effector.ProcessEffector):
 
     @property
     def _compile_output_filehandle(self):
-        fh_mode = 'r+w'
+        fh_mode = 'r+'
         if (
             (
                 self._compile_job.compile_action is COMPILE_ACTION.Initiate

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -315,7 +315,7 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
     if not data_object:
         data_object = request.values
 
-    gs_image = calibration.get_grayscale_slice(
+    grayscale_image = calibration.get_grayscale_slice(
         ccc_identifier, image_identifier)
     image_data = calibration.get_image_json_from_ccc(
         ccc_identifier, image_identifier)
@@ -327,11 +327,11 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
             reason='Unknown image or CCC'
         )
 
-    grayscale_object = get_grayscale(gs_name)
+    grayscale_config = get_grayscale(gs_name)
     try:
         _, values = detect_grayscale(
-            gs_image,
-            gs_name,
+            grayscale_image,
+            grayscale_config,
             debug=False,
         )
     except GrayscaleError:
@@ -339,7 +339,7 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
             400,
             reason='Failed to detect grayscale'
         )
-    valid = get_grayscale_is_valid(values, grayscale_object)
+    valid = get_grayscale_is_valid(values, grayscale_config)
     if not valid:
         return json_abort(
             400,
@@ -349,7 +349,7 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
     success = calibration.set_image_info(
         ccc_identifier, image_identifier,
         grayscale_source_values=values,
-        grayscale_target_values=grayscale_object.targets,
+        grayscale_target_values=grayscale_config.targets,
         access_token=data_object.get("access_token")
     )
 
@@ -357,7 +357,7 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
 
         return jsonify(
             source_values=values,
-            target_values=grayscale_object.targets
+            target_values=grayscale_config.targets
         )
 
     else:

--- a/scanomatic/ui_server/calibration_api.py
+++ b/scanomatic/ui_server/calibration_api.py
@@ -329,7 +329,7 @@ def analyse_ccc_image_grayscale(ccc_identifier, image_identifier):
 
     grayscale_config = get_grayscale(gs_name)
     try:
-        _, values = detect_grayscale(
+        values = detect_grayscale(
             grayscale_image,
             grayscale_config,
             debug=False,

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -370,7 +370,7 @@ def add_routes(app, rpc_client, is_debug_mode):
                 fixture.im,
                 grayscale_config,
             )
-            _, values = detect_grayscale(
+            values = detect_grayscale(
                 grayscale_im, grayscale_config, debug=is_debug_mode,
             )
         except (TypeError, GrayscaleError):
@@ -592,7 +592,7 @@ def add_routes(app, rpc_client, is_debug_mode):
                     fixture.im,
                     grayscale_config,
                 )
-                _, values = detect_grayscale(grayscale_im, grayscale_config)
+                values = detect_grayscale(grayscale_im, grayscale_config)
             except (TypeError, GrayscaleError):
 
                 return jsonify(

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -16,12 +16,14 @@ from scanomatic.data_processing.calibration import (
 from scanomatic.data_processing.norm import NormState
 from scanomatic.data_processing.project import path_has_saved_project_state
 from scanomatic.image_analysis.first_pass_image import FixtureImage
-from scanomatic.image_analysis.grayscale import \
-    get_grayscale as get_grayscale_conf
+from scanomatic.image_analysis.grayscale import get_grayscale
 from scanomatic.image_analysis.grayscale import get_grayscale_names
 from scanomatic.image_analysis.grid_cell import GridCell
 from scanomatic.image_analysis.image_basics import Image_Transpose
-from scanomatic.image_analysis.grayscale_detection import detect_grayscale
+from scanomatic.image_analysis.grayscale_detection import (
+    detect_grayscale,
+    get_grayscale_im_section,
+)
 from scanomatic.image_analysis.support import save_image_as_png
 from scanomatic.image_analysis.exceptions import GrayscaleError
 from scanomatic.io.fixtures import Fixtures
@@ -362,22 +364,22 @@ def add_routes(app, rpc_client, is_debug_mode):
         )
 
         fixture = get_fixture_image_by_name(fixture_name)
-
+        grayscale_config = get_grayscale(grayscale_area_model.name)
         try:
+            grayscale_im = get_grayscale_im_section(fixture.im, grayscale_config)
             _, values = detect_grayscale(
-                fixture.im, grayscale_area_model, debug=is_debug_mode)
+                grayscale_im, grayscale_config, debug=is_debug_mode)
         except (TypeError, GrayscaleError):
             return jsonify(
                 success=False, is_endpoint=True,
                 reason="Grayscale detection failed")
 
-        grayscale_object = get_grayscale_conf(grayscale_area_model.name)
-        valid = get_grayscale_is_valid(values, grayscale_object)
+        valid = get_grayscale_is_valid(values, grayscale_config)
 
         return jsonify(
             success=True,
             source_values=values,
-            target_values=grayscale_object.targets,
+            target_values=grayscale_config.targets,
             grayscale=valid,
             reason=None if valid else "No Grayscale",
         )
@@ -579,9 +581,11 @@ def add_routes(app, rpc_client, is_debug_mode):
                 )
 
             grayscale_area_model.name = grayscale_name
+            grayscale_config = get_grayscale(grayscale_area_model.name)
 
             try:
-                _, values = detect_grayscale(fixture.im, grayscale_area_model)
+                grayscale_im = get_grayscale_im_section(fixture.im, grayscale_config)
+                _, values = detect_grayscale(grayscale_im, grayscale_config)
             except (TypeError, GrayscaleError):
 
                 return jsonify(
@@ -589,8 +593,7 @@ def add_routes(app, rpc_client, is_debug_mode):
                     reason="Could not detect grayscale",
                 )
 
-            grayscale_object = get_grayscale_conf(grayscale_area_model.name)
-            valid = get_grayscale_is_valid(values, grayscale_object)
+            valid = get_grayscale_is_valid(values, grayscale_config)
 
             if not valid:
                 return jsonify(
@@ -838,7 +841,7 @@ def add_routes(app, rpc_client, is_debug_mode):
         grayscale_targets = np.array(data_object.get("grayscale_targets", []))
 
         if not grayscale_targets:
-            grayscale_targets = get_grayscale_conf(
+            grayscale_targets = get_grayscale(
                 data_object.get("grayscale_name", ""),
             ).targets
 

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -304,13 +304,13 @@ def add_routes(app, rpc_client, is_debug_mode):
                 success=False, is_endpoint=True,
                 reason="Grayscale detection failed")
 
-        grayscale_object = get_grayscale_conf(grayscale_area_model.name)
-        valid = get_grayscale_is_valid(values, grayscale_object)
+        grayscale_config = get_grayscale(grayscale_area_model.name)
+        valid = get_grayscale_is_valid(values, grayscale_config)
 
         return jsonify(
             success=valid,
             source_values=values,
-            target_values=grayscale_object.targets,
+            target_values=grayscale_config.targets,
             grayscale=grayscale_area_model.name,
             reason=(
                 None if valid else
@@ -366,7 +366,10 @@ def add_routes(app, rpc_client, is_debug_mode):
         fixture = get_fixture_image_by_name(fixture_name)
         grayscale_config = get_grayscale(grayscale_area_model.name)
         try:
-            grayscale_im = get_grayscale_im_section(fixture.im, grayscale_config)
+            grayscale_im = get_grayscale_im_section(
+                fixture.im,
+                grayscale_config,
+            )
             _, values = detect_grayscale(
                 grayscale_im, grayscale_config, debug=is_debug_mode)
         except (TypeError, GrayscaleError):
@@ -584,7 +587,10 @@ def add_routes(app, rpc_client, is_debug_mode):
             grayscale_config = get_grayscale(grayscale_area_model.name)
 
             try:
-                grayscale_im = get_grayscale_im_section(fixture.im, grayscale_config)
+                grayscale_im = get_grayscale_im_section(
+                    fixture.im,
+                    grayscale_config,
+                )
                 _, values = detect_grayscale(grayscale_im, grayscale_config)
             except (TypeError, GrayscaleError):
 

--- a/scanomatic/ui_server/data_api.py
+++ b/scanomatic/ui_server/data_api.py
@@ -371,7 +371,8 @@ def add_routes(app, rpc_client, is_debug_mode):
                 grayscale_config,
             )
             _, values = detect_grayscale(
-                grayscale_im, grayscale_config, debug=is_debug_mode)
+                grayscale_im, grayscale_config, debug=is_debug_mode,
+            )
         except (TypeError, GrayscaleError):
             return jsonify(
                 success=False, is_endpoint=True,

--- a/scanomatic/ui_server_data/js/som/compile.js
+++ b/scanomatic/ui_server_data/js/som/compile.js
@@ -90,8 +90,8 @@ function GetIncludedImageList(forceList) {
   let images = null;
   if (forceList || imageListDiv.find('#manual-selection').prop('checked')) {
     images = [];
-    imageListDiv.find('#options').children().each(() => {
-      const imp = $(this).find(':input');
+    imageListDiv.find('#options').children().each((_, child) => {
+      const imp = $(child).find(':input');
       if (imp.prop('checked') === true) {
         images.push(imp.val());
       }

--- a/scanomatic/ui_server_data/style/analysis.css
+++ b/scanomatic/ui_server_data/style/analysis.css
@@ -44,3 +44,8 @@
   height: 320px;
   display: block;
 }
+
+#submit-button {
+  padding: 3px;
+  color: #333;
+}

--- a/scanomatic/ui_server_data/style/compilation.css
+++ b/scanomatic/ui_server_data/style/compilation.css
@@ -43,3 +43,8 @@ label.image-list-label {
   padding: 5px;
   background: #541f0f !important;
 }
+
+#submit-button {
+  padding: 3px;
+  color: #333;
+}


### PR DESCRIPTION
Resolves #46 and #132 (I think?)

- [x] Compile project works using both local and global fixture configs in json format 
The global fixture config file **must** be named "almost" like its `name` field, e.g if the name field states `Delta 1`, the file must be named `delta_1.config`
- [x] Analysis works with default settings
I'm not able to get the "Manual regridding of previously analysed project" to be activated, but I don't see any errors, so not sure if I'm missing something here