### PR TITLE
Use npm ci instead of npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
         - name: Install
           run: |
-            npm install
+            npm ci
 
         - name: Lint
           run: |
@@ -31,7 +31,7 @@ jobs:
 
         - name: Install
           run: |
-            npm install
+            npm ci
 
         - name: Test
           run: |
@@ -44,7 +44,7 @@ jobs:
 
         - name: Install
           run: |
-            npm install
+            npm ci
 
         - name: Builds
           run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16 as npmbuilder
 COPY . /src
 WORKDIR /src
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 FROM python:3.9


### PR DESCRIPTION
Small PR to use the version safe `npm ci` instead of `npm install` in GitHub CI and Dockerfile.