### PR TITLE
Issue 47 validate qc part 2

### DIFF
--- a/scanomatic/ui_server_data/js/som/qc_normAPIHelper.js
+++ b/scanomatic/ui_server_data/js/som/qc_normAPIHelper.js
@@ -1,8 +1,9 @@
 import $ from 'jquery';
-import * as d3 from 'd3';
 
 import { getLastSegmentOfPath } from './qc_normHelper';
 import { setSharedValue } from './helpers';
+
+const d3 = require('d3/d3.js');
 
 const baseUrl = '';
 setSharedValue('baseUrl', baseUrl);

--- a/scanomatic/ui_server_data/js/som/qc_normDrawCurves.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawCurves.js
@@ -1,5 +1,6 @@
-import * as d3 from 'd3';
 import { getExtentFromMultipleArrs, getBaseLog } from './qc_normHelper';
+
+const d3 = require('d3/d3.js');
 
 if (!d3.scanomatic) {
   d3.scanomatic = {};
@@ -74,7 +75,6 @@ d3.scanomatic.growthChart = () => {
   let generationTimeWhen;
   let generationTime;
   let growthYield;
-
 
   // local variables
   let g;

--- a/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
@@ -1,4 +1,4 @@
-import * as d3 from 'd3';
+const d3 = require('d3/d3.js');
 
 const classExperimentSelected = 'ExperimentSelected';
 const dispatcherSelectedExperiment = 'SelectedExperiment';
@@ -170,7 +170,11 @@ function addSelectionHandling(svgRoot) {
     .on(
       'mouseout',
       () => {
-        if (d3.event.relatedTarget != null && d3.event.relatedTarget.tagName === 'HTML') {
+        if (
+          d3.event != null
+          && d3.event.relatedTarget != null
+          && d3.event.relatedTarget.tagName === 'HTML'
+        ) {
           svgRoot.selectAll('rect.selection').remove();
           d3.selectAll('g.expNode.selection').classed('selection', false);
         }

--- a/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
@@ -652,13 +652,13 @@ d3.scanomatic.plateHeatmap = () => {
           const x = margin + (j * cellSize);
           const y = margin + (i * cellSize);
           const metaGt = (
-            growthMetaData.gt === undefined ? null : growthMetaData.gt[i][j]
+            growthMetaData.gt == null ? null : growthMetaData.gt[i][j]
           );
           const metaGtWhen = (
-            growthMetaData.gtWhen === undefined ? null : growthMetaData.gtWhen[i][j]
+            growthMetaData.gtWhen == null ? null : growthMetaData.gtWhen[i][j]
           );
           const metaYield = (
-            growthMetaData.yld === undefined ? null : growthMetaData.yld[i][j]
+            growthMetaData.yld == null ? null : growthMetaData.yld[i][j]
           );
           const col = {
             col: j,

--- a/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
@@ -816,9 +816,9 @@ d3.scanomatic.plateHeatmap = () => {
     data = value;
     cols = data[0].length;
     rows = data.length;
-    phenotypeMin = d3.min(data, array => d3.min(array));
-    phenotypeMax = d3.max(data, array => d3.max(array));
-    phenotypeMean = d3.mean(data, array => d3.mean(array));
+    phenotypeMin = d3.min(data, (array) => d3.min(array));
+    phenotypeMax = d3.max(data, (array) => d3.max(array));
+    phenotypeMean = d3.mean(data, (array) => d3.mean(array));
     return heatmap;
   };
 


### PR DESCRIPTION
Would have been nice to use `??`, but alas... Anyway, this very small PR makes it possible to view normalized phenotypes.

Unfortunately, D3 3.X doesn't play well with new style imports and the way we use the module, so I've changed to `require` for this. This solves the legion of console errors. (Note that D3 is now on 7.3.0, so upgrading will likely be painful...)

Part of #47 (I think I can now do QC, but won't say it's resolved because I'm not sure I've actually validated it enough, for instance I have only tried on old projects ~and there are still console errors~.)