### PR TITLE
Validate feature extraction

### DIFF
--- a/scanomatic/data_processing/growth_phenotypes.py
+++ b/scanomatic/data_processing/growth_phenotypes.py
@@ -363,7 +363,7 @@ def generation_time_when(
     linregress_extent: int,
     **kwargs,
 ) -> float:
-    pos = index + linregress_extent
+    pos = int(index + linregress_extent)
     if pos < 0:
         _logger.warning("No GT When because no finite slopes in data")
         return np.nan

--- a/scanomatic/data_processing/growth_phenotypes.py
+++ b/scanomatic/data_processing/growth_phenotypes.py
@@ -363,7 +363,7 @@ def generation_time_when(
     linregress_extent: int,
     **kwargs,
 ) -> float:
-    pos = int(index + linregress_extent)
+    pos = index + linregress_extent
     if pos < 0:
         _logger.warning("No GT When because no finite slopes in data")
         return np.nan

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -1077,7 +1077,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
                 plate_flat_regression_strided,
             ):
                 id1 = pos_index % plate.shape[1]
-                id0 = pos_index / plate.shape[1]
+                id0 = int(pos_index / plate.shape[1])
 
                 curve_data = get_preprocessed_data_for_phenotypes(
                     curve=plate[id0, id1],

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -1021,7 +1021,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         all_vector_meta_phenotypes = []
 
         regression_size = self._settings.linear_regression_size
-        position_offset = (regression_size - 1) / 2
+        position_offset = (regression_size - 1) // 2
         phenotypes_count = self.get_number_of_phenotypes()
 
         total_curves = float(self.number_of_curves)
@@ -1077,7 +1077,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
                 plate_flat_regression_strided,
             ):
                 id1 = pos_index % plate.shape[1]
-                id0 = int(pos_index / plate.shape[1])
+                id0 = pos_index // plate.shape[1]
 
                 curve_data = get_preprocessed_data_for_phenotypes(
                     curve=plate[id0, id1],

--- a/scanomatic/ui_server_data/analysis.html
+++ b/scanomatic/ui_server_data/analysis.html
@@ -130,7 +130,7 @@
             </label>
           </div>
         </div>
-        <button type="button" id="submit-button"
+        <button type="button" id="submit-button" class="submit-button"
             onclick="som.Analyse(this);">
           Run Analysis
         </button>

--- a/scanomatic/ui_server_data/compile.html
+++ b/scanomatic/ui_server_data/compile.html
@@ -70,7 +70,7 @@
           </div>
         </div>
         <div class="section">
-          <button type="button" id="submit-button"
+          <button type="button" id="submit-button" class="submit-button"
               onclick="som.Compile(this);">
             Compile Project
           </button>

--- a/scanomatic/ui_server_data/experiment.html
+++ b/scanomatic/ui_server_data/experiment.html
@@ -278,7 +278,7 @@
       </div>
 
       <div class="section">
-        <button type="button" id="submit-button"
+        <button type="button" id="submit-button" class="submit-button"
             onclick="som.StartExperiment(this)">
           Start Scanning
         </button>

--- a/scanomatic/ui_server_data/feature_extract.html
+++ b/scanomatic/ui_server_data/feature_extract.html
@@ -45,7 +45,7 @@
           </div>
         </div>
 
-        <button type="button" id="submit-button2"
+        <button type="button" id="submit-button2" class="submit-button"
             onclick="som.Extract(this);">
           Run Feature Extraction
         </button>
@@ -67,7 +67,7 @@
           <code>root/</code> or it won't work.  A folder will be
           created in which the output is stored.
         </em></div>
-        <button type="button" id="submit-button3"
+        <button type="button" id="submit-button3" class="submit-button"
             onclick="som.BioscreenExtract(this);">
           Run Feature Extraction
         </button>

--- a/scanomatic/ui_server_data/style/analysis.css
+++ b/scanomatic/ui_server_data/style/analysis.css
@@ -44,8 +44,3 @@
   height: 320px;
   display: block;
 }
-
-#submit-button {
-  padding: 3px;
-  color: #333;
-}

--- a/scanomatic/ui_server_data/style/compilation.css
+++ b/scanomatic/ui_server_data/style/compilation.css
@@ -43,8 +43,3 @@ label.image-list-label {
   padding: 5px;
   background: #541f0f !important;
 }
-
-#submit-button {
-  padding: 3px;
-  color: #333;
-}

--- a/scanomatic/ui_server_data/style/main.css
+++ b/scanomatic/ui_server_data/style/main.css
@@ -441,3 +441,8 @@ label {
   background: #f8e03e !important;
   margin: 6px 6px 0px 0px;
 }
+
+.submit-button {
+  padding: 3px;
+  color: #333;
+}


### PR DESCRIPTION
Part of #141 

- [x] Feature extraction can be run and the results can be opened in QC.
- [x] Improved readability of the submit buttons


Part of the task was to validate that the results are the same as in the old project, and they are not. They seem to be different right from the initial project compilation step so not really sure it is due to the feature extraction.

Here is a summary of what I found

# 2 - Compile Project
With local fixture
## Produces
- `*.project.compilation`
- `*.project.compilation.instructions`

## Differences

### `*.project.compilation`
- Skipped index 0 image
- Grayscale has slight differences in coordinates and decimals in values
- Orientation marks slightly different
- FixturePlateModel coordinates slightly different

## Errors
`2022-01-28 08:21:55 -- ERROR	**Compile Effector** Could not output analysis to file /somprojects/PayamMartin19Oct16Scanner2/PayamMartin19Oct16Scanner2_0000_30.2968.tiff`

# 3 - Analysis
With dynamic positioning
## Produces
- `grid_plate___*.npy`
- `grid_size___*.npy`
- `time_data.npy`
- `image_*_data.npy`

## Differences
### `grid_plate___*.npy`
Same shape but slightly different values by single digits

### `image_*_data.npy`
- The file with the last index is missing, due to missing index 0 in compilation probably
- The numbers are different by about factor 2

### `time_data.npy`
- Shape is off by one, first element is missing, due to missing index 0 in compilation probably

# 4 - Feature extraction
Run with overwriting QC
## Produces
- `curves_raw.npy`
- `curves_smooth.npy`
- `normalized_phenotypes.npy`
- `phenotype_params.json`
- `phenotypes.Absolute.plate_*.csv`
- `phenotypes.extraction.instructions`
- `phenotypes_filter.npy`
- `phenotypes_meta_vector_raw.npy`
- `phenotypes_raw.npy`
- `phenotypes_reference_offsets.npy`
- `phenotype_vectors_raw.npy`
- `phenotype_times.npy`

## Differences

### `curves_raw.npy` and `curves_smooth.npy`
- Shape is off by one, probably same issue as earlier
- Numbers are off by about factor 2

### `phenotypes.Absolute.plate_*.csv`
- 5 more columns in new version
- Numbers are off

### `phenotypes_filter.npy`
- Old one can't be opened

### `phenotypes_raw.npy`
- New format so difficult to compare

### `phenotype_vectors_raw.npy`
- Old one is empty

### `phenotype_times.npy`
- First element is missing
