### PR TITLE
Fix non optional params

### DIFF
--- a/scanomatic/data_processing/pheno/state.py
+++ b/scanomatic/data_processing/pheno/state.py
@@ -29,6 +29,10 @@ PlateByCurveMetaPhenotypeArrays = npt.NDArray[
 ]
 
 
+DEFAULT_NO_GROWTH_THRESHOLD = 0.6
+DEFAULT_DOUBLING_THRESHOLD = 1.0
+
+
 @dataclass
 class PhenotyperSettings:
     median_kernel_size: int
@@ -37,8 +41,8 @@ class PhenotyperSettings:
     phenotypes_inclusion: Optional[PhenotypeDataType] = (
         PhenotypeDataType.Trusted
     )
-    no_growth_monotonicity_threshold: Optional[float] = None
-    no_growth_pop_doublings_threshold: Optional[float] = None
+    no_growth_monotonicity_threshold: float = DEFAULT_NO_GROWTH_THRESHOLD
+    no_growth_pop_doublings_threshold: float = DEFAULT_DOUBLING_THRESHOLD
 
     def __post_init__(self):
         assert (

--- a/scanomatic/data_processing/phenotyper.py
+++ b/scanomatic/data_processing/phenotyper.py
@@ -48,6 +48,8 @@ from scanomatic.data_processing.phases.features import (
 )
 from scanomatic.data_processing.pheno.save import save_state, save_state_to_zip
 from scanomatic.data_processing.pheno.state import (
+    DEFAULT_NO_GROWTH_THRESHOLD,
+    DEFAULT_DOUBLING_THRESHOLD,
     PhenotyperSettings,
     PhenotyperState
 )
@@ -135,8 +137,8 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
         median_kernel_size: int = 5,
         gaussian_filter_sigma: float = 1.5,
         linear_regression_size: int = 5,
-        no_growth_monotonocity_threshold: float = 0.6,
-        no_growth_pop_doublings_threshold: float = 1.0,
+        no_growth_monotonicity_threshold: float = DEFAULT_NO_GROWTH_THRESHOLD,
+        no_growth_pop_doublings_threshold: float = DEFAULT_DOUBLING_THRESHOLD,
         base_name=None,
         run_extraction=False,
         phenotypes=None,
@@ -149,7 +151,7 @@ class Phenotyper(mock_numpy_interface.NumpyArrayInterface):
             gaussian_filter_sigma=gaussian_filter_sigma,
             linear_regression_size=linear_regression_size,
             phenotypes_inclusion=phenotypes_inclusion,
-            no_growth_monotonicity_threshold=no_growth_monotonocity_threshold,
+            no_growth_monotonicity_threshold=no_growth_monotonicity_threshold,
             no_growth_pop_doublings_threshold=(
                 no_growth_pop_doublings_threshold
             ),

--- a/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
+++ b/scanomatic/ui_server_data/js/som/qc_normDrawPlate.js
@@ -816,9 +816,9 @@ d3.scanomatic.plateHeatmap = () => {
     data = value;
     cols = data[0].length;
     rows = data.length;
-    phenotypeMin = d3.min(data, array => d3.min(array));
-    phenotypeMax = d3.max(data, array => d3.max(array));
-    phenotypeMean = d3.mean(data, array => d3.mean(array));
+    phenotypeMin = d3.min(data, (array) => d3.min(array));
+    phenotypeMax = d3.max(data, (array) => d3.max(array));
+    phenotypeMean = d3.mean(data, (array) => d3.mean(array));
     return heatmap;
   };
 


### PR DESCRIPTION
When trying to load an analysis from `analysis_original` in QC it became evident that these are not actually optional.