### PR TITLE
regridding ui

### DIFF
--- a/scanomatic/ui_server_data/analysis.html
+++ b/scanomatic/ui_server_data/analysis.html
@@ -5,6 +5,8 @@
   <script src="/js/somlib/som.js"></script>
   <script>
     som.setSharedValue("currentFixtureId", "#current-fixture");
+    som.setSharedValue("newFixtureDataId", "#new-fixture-data");
+    som.setSharedValue("selectedFixtureDivId", "#selected-fixture");
   </script>
   <link rel="stylesheet" type="text/css" href="style/main.css?ver=_-_VERSIONTAG_-_">
   <link rel="stylesheet" type="text/css" href="style/analysis.css?ver=_-_VERSIONTAG_-_">

--- a/scanomatic/ui_server_data/js/som/analysis.js
+++ b/scanomatic/ui_server_data/js/som/analysis.js
@@ -145,6 +145,7 @@ function regriddingSettingsData() {
 export function toggleManualRegridding(chkbox) {
   const isActive = $(chkbox).prop('checked');
   if (isActive) {
+    setFixturePlateListing();
     $('#manual-regridding-settings').show();
   } else {
     $('#manual-regridding-settings').hide();
@@ -190,7 +191,7 @@ export function setAnalysisDirectory(input, validate) {
 export function setFilePath(input, suffix, suffixPattern, toggleRegriddingIfNotExists) {
   getPathSuggestions(
     input,
-    false,
+    true,
     suffix,
     suffixPattern,
     (data) => {

--- a/scanomatic/ui_server_data/js/som/analysis.js
+++ b/scanomatic/ui_server_data/js/som/analysis.js
@@ -191,7 +191,7 @@ export function setAnalysisDirectory(input, validate) {
 export function setFilePath(input, suffix, suffixPattern, toggleRegriddingIfNotExists) {
   getPathSuggestions(
     input,
-    true,
+    false,
     suffix,
     suffixPattern,
     (data) => {


### PR DESCRIPTION
This small PR deals with getting the regridding UI to show up / work on the analysis page.
The screenshot below shows that this PR make it possible to enable the regridding:
![Screenshot from 2022-02-09 12-43-44](https://user-images.githubusercontent.com/48437915/153210051-06490d4d-4470-44b1-888e-f3f88319534c.png)



I first made an analysis without regridding, and here is a quality control from this:


![Screenshot from 2022-02-09 14-19-17](https://user-images.githubusercontent.com/48437915/153209445-83252d45-58fa-4893-b73c-5664c126447b.png)

I then made an analysis with regridding (with regridding setting as in the first figure), and the quality control looks like this:

![Screenshot from 2022-02-09 14-18-13](https://user-images.githubusercontent.com/48437915/153209559-f71b86fb-3f55-4858-b241-379db8fff761.png)

the two figures clearly differ but do not know if this looks ok.





Resolves #153 